### PR TITLE
fix: recognize /backend-api/ requests from pi-cliproxyapi-provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Pi reset produced an invalid empty configuration** (`AgentConfigurationService.cs`): resetting Pi after removing its last managed provider now preserves the required `"providers": {}` root instead of writing `{}`, preventing Pi from rejecting `~/.pi/agent/models.json`.
+- **CLIProxyAPI requests through the pi-cliproxyapi-provider extension missing from logs/stats** (`RequestLogEntry.cs`): the official [pi-cliproxyapi-provider](https://github.com/router-for-me/pi-cliproxyapi-provider) extension registers inference at `{root}/backend-api/` and sends Codex-style traffic to `/backend-api/codex/responses` instead of the standard `/v1/chat/completions` or `/v1/messages` paths. `IsAiPath`/`InferProvider` only recognized `/v1/*`, `/v1beta/models/`, and `/api/provider/*`, so these requests were silently dropped. `/backend-api/*` paths are now recognized, with `/backend-api/codex/*` tagged as **Codex** and other `/backend-api/*` paths as **OpenAI Completions**.
 
 ## [1.0.3] - 2026-07-23
 

--- a/src/TunnelAgent.Avalonia/ViewModels/RequestLogEntry.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/RequestLogEntry.cs
@@ -91,7 +91,8 @@ public sealed partial class RequestLogEntry
         path.StartsWith("/v1/completions",      StringComparison.OrdinalIgnoreCase) ||
         path.StartsWith("/v1beta/models/",      StringComparison.OrdinalIgnoreCase) ||
         path.StartsWith("/v1/responses",        StringComparison.OrdinalIgnoreCase) ||
-        path.StartsWith("/api/provider/",       StringComparison.OrdinalIgnoreCase);
+        path.StartsWith("/api/provider/",       StringComparison.OrdinalIgnoreCase) ||
+        path.StartsWith("/backend-api/",        StringComparison.OrdinalIgnoreCase);
 
     private static string InferProvider(string path)
     {
@@ -104,6 +105,16 @@ public sealed partial class RequestLogEntry
         {
             var seg = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
             return seg.Length >= 2 ? Titlecase(seg[1]) : "Custom";
+        }
+        // pi-cliproxyapi-provider extension: registers inference at
+        // "{root}/backend-api/" and sends Codex-style traffic to
+        // "/backend-api/codex/responses".
+        if (path.StartsWith("/backend-api/",         StringComparison.OrdinalIgnoreCase))
+        {
+            var seg = path.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            return seg.Length >= 2 && seg[1].Equals("codex", StringComparison.OrdinalIgnoreCase)
+                ? "Codex"
+                : "OpenAI Completions";
         }
         return "OpenAI Completions";
     }

--- a/tests/TunnelAgent.Tests/RequestLogEntryTests.cs
+++ b/tests/TunnelAgent.Tests/RequestLogEntryTests.cs
@@ -1,0 +1,26 @@
+using TunnelAgent.ViewModels;
+
+namespace TunnelAgent.Tests;
+
+public class RequestLogEntryTests
+{
+    [Fact]
+    public void ParsesBackendApiCodexPath_AsCodex()
+    {
+        var line = "[2026-06-04 11:35:10] [5e01a728] [info ] [gin_logger.go:101] 200 |       14.832s |       127.0.0.1 | POST    \"/backend-api/codex/responses\"";
+        var entry = RequestLogEntry.TryParse(line);
+
+        Assert.NotNull(entry);
+        Assert.Equal("Codex", entry!.Provider);
+    }
+
+    [Fact]
+    public void ParsesUnknownBackendApiPath_AsOpenAiCompletions()
+    {
+        var line = "[2026-06-04 11:35:10] [5e01a728] [info ] [gin_logger.go:101] 200 |       14.832s |       127.0.0.1 | POST    \"/backend-api/other\"";
+        var entry = RequestLogEntry.TryParse(line);
+
+        Assert.NotNull(entry);
+        Assert.Equal("OpenAI Completions", entry!.Provider);
+    }
+}


### PR DESCRIPTION
## Problem

The official [pi-cliproxyapi-provider](https://github.com/router-for-me/pi-cliproxyapi-provider) extension registers inference at `{root}/backend-api/` and sends Codex-style traffic to `/backend-api/codex/responses`, instead of the standard `/v1/chat/completions` or `/v1/messages` paths CLIProxyAPI normally serves.

`RequestLogEntry.IsAiPath`/`InferProvider` only recognized `/v1/*`, `/v1beta/models/`, and `/api/provider/*` paths, so requests coming through this extension were silently dropped from the log viewer and usage stats.

## Fix

Add `/backend-api/` recognition to `IsAiPath` and `InferProvider`:
- `/backend-api/codex/*` → tagged `Codex`
- other `/backend-api/*` paths → tagged `OpenAI Completions`

## Scope note

This only fixes log/stats parsing for `/backend-api/` traffic. TunnelAgent's own generated pi config (`AgentConfigurationService.BuildPiProviderBlock`) targets pi's native `openai-completions`/`anthropic-messages` provider types against CLIProxyAPI's standard `/v1` endpoints — that's unaffected and unrelated to this third-party extension's separate config file (`~/.pi/agent/cliproxyapi.json`).

## Testing

Added `tests/TunnelAgent.Tests/RequestLogEntryTests.cs` covering `/backend-api/codex/responses` → `Codex` and an unknown `/backend-api/*` path → `OpenAI Completions`.

```
dotnet test tests/TunnelAgent.Tests --filter RequestLogEntryTests
Passed!  - Failed: 0, Passed: 2, Skipped: 0, Total: 2
```