### PR TITLE
Replace OpenRouter metadata with models.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@
 - 🎚️ **Model Visibility**: browse available models grouped by connected provider or engine source, including Perplexity-backed model listings
 - 🔁 **Model Fallback**: create virtual models backed by ordered provider/model chains, automatically fail over when quota is exhausted, expose the virtual models through `/v1/models`, and cache the last working route for a configurable duration
 - 📈 **Usage Dashboard**: Home view with live usage telemetry (calls, tokens, success rate) over selectable time ranges, an interactive usage chart, and a summary table that groups by provider or model — backed by SQLite history that persists across restarts
-- 💰 **Cost Estimation**: per-request cost estimates using live OpenRouter pricing (input/output/cache read & write rates) cached on disk for offline use, with a built-in price table fallback
+- 💰 **Cost Estimation**: per-request cost estimates using live models.dev pricing (input/output/cache read & write rates) cached on disk for offline use, with a built-in price table fallback
 - 📊 **Live Status**: see sidebar engine health plus focused engine state, endpoint, and release info
 - ⚙️ **Configuration**: control startup behaviour, per-engine ports, updates, release selection, routing strategy, and credential actions
 

--- a/src/TunnelAgent.Avalonia/Services/AgentConfigurationService.cs
+++ b/src/TunnelAgent.Avalonia/Services/AgentConfigurationService.cs
@@ -413,7 +413,7 @@ public sealed class AgentConfigurationService
 
     private static JsonObject BuildOpenCodeProvidersBlock(
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo> modelInfoMap)
+        Dictionary<string, ModelsDevService.ModelInfo> modelInfoMap)
     {
         var cliproxy   = entries.Where(m => !IsPerplexityEntry(m)).ToList();
         var perplexity = entries.Where(IsPerplexityEntry).ToList();
@@ -427,7 +427,7 @@ public sealed class AgentConfigurationService
 
     private static JsonObject BuildOpenCodeProviderBlock(
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo> modelInfoMap)
+        Dictionary<string, ModelsDevService.ModelInfo> modelInfoMap)
     {
         var first   = entries[0];
         var options = new JsonObject
@@ -544,13 +544,13 @@ public sealed class AgentConfigurationService
     private static bool IsAnthropicEntry(ModelEntry m) =>
         !string.IsNullOrEmpty(m.OwnedBy) && m.OwnedBy.Equals("anthropic", StringComparison.OrdinalIgnoreCase);
 
-    private static async Task<Dictionary<string, OpenRouterContextService.ModelInfo>> BuildModelInfoMapAsync(
+    private static async Task<Dictionary<string, ModelsDevService.ModelInfo>> BuildModelInfoMapAsync(
         IEnumerable<string> modelIds, CancellationToken ct)
     {
-        var map = new Dictionary<string, OpenRouterContextService.ModelInfo>(StringComparer.OrdinalIgnoreCase);
+        var map = new Dictionary<string, ModelsDevService.ModelInfo>(StringComparer.OrdinalIgnoreCase);
         foreach (var id in modelIds)
         {
-            var info = await OpenRouterContextService.Instance.GetModelInfoAsync(id, ct).ConfigureAwait(false);
+            var info = await ModelsDevService.Instance.GetModelInfoAsync(id, ct).ConfigureAwait(false);
             if (info is not null) map[id] = info;
         }
         return map;
@@ -558,7 +558,7 @@ public sealed class AgentConfigurationService
 
     private static JsonObject BuildPiProvidersBlock(
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo> modelInfoMap)
+        Dictionary<string, ModelsDevService.ModelInfo> modelInfoMap)
     {
         var cliproxy   = entries.Where(m => !IsAnthropicEntry(m) && !IsPerplexityEntry(m)).ToList();
         var cliproxyAnthropic = entries.Where(IsAnthropicEntry).ToList();
@@ -575,7 +575,7 @@ public sealed class AgentConfigurationService
 
     private static JsonObject BuildPiProviderBlock(
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo> modelInfoMap,
+        Dictionary<string, ModelsDevService.ModelInfo> modelInfoMap,
         string api = "openai-completions")
     {
         var first    = entries[0];
@@ -612,7 +612,7 @@ public sealed class AgentConfigurationService
     internal static string MergeOmpModelsYaml(
         string existing,
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo>? modelInfoMap,
+        Dictionary<string, ModelsDevService.ModelInfo>? modelInfoMap,
         bool remove)
     {
         var stream = new YamlStream();
@@ -665,7 +665,7 @@ public sealed class AgentConfigurationService
 
         if (!remove)
         {
-            var metadata = modelInfoMap ?? new Dictionary<string, OpenRouterContextService.ModelInfo>(StringComparer.OrdinalIgnoreCase);
+            var metadata = modelInfoMap ?? new Dictionary<string, ModelsDevService.ModelInfo>(StringComparer.OrdinalIgnoreCase);
             var openAi = entries.Where(m => !IsAnthropicEntry(m) && !IsPerplexityEntry(m)).ToList();
             var anthropic = entries.Where(IsAnthropicEntry).ToList();
             if (openAi.Count > 0)
@@ -687,7 +687,7 @@ public sealed class AgentConfigurationService
 
     private static YamlMappingNode BuildOmpProviderBlock(
         IReadOnlyList<ModelEntry> entries,
-        IReadOnlyDictionary<string, OpenRouterContextService.ModelInfo> modelInfoMap,
+        IReadOnlyDictionary<string, ModelsDevService.ModelInfo> modelInfoMap,
         string api)
     {
         var first = entries[0];
@@ -739,7 +739,7 @@ public sealed class AgentConfigurationService
             ? await File.ReadAllTextAsync(configPath, ct).ConfigureAwait(false)
             : string.Empty;
         var metadata = remove || modelEntries is not { Count: > 0 }
-            ? new Dictionary<string, OpenRouterContextService.ModelInfo>(StringComparer.OrdinalIgnoreCase)
+            ? new Dictionary<string, ModelsDevService.ModelInfo>(StringComparer.OrdinalIgnoreCase)
             : await BuildModelInfoMapAsync(modelEntries.Select(m => m.Id), ct).ConfigureAwait(false);
         var content = MergeOmpModelsYaml(
             existing,
@@ -974,7 +974,7 @@ public sealed class AgentConfigurationService
 
     private AgentConfigApplyResult WriteGrokConfig(
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo>? modelInfoMap,
+        Dictionary<string, ModelsDevService.ModelInfo>? modelInfoMap,
         string apiKey, string proxyBaseUrl, bool remove, IReadOnlyCollection<int>? managedPorts = null)
     {
         var configPath = ExpandPath(GrokConfigPath);
@@ -1020,7 +1020,7 @@ public sealed class AgentConfigurationService
     internal static string MergeGrokConfig(
         string existing,
         IReadOnlyList<ModelEntry> entries,
-        Dictionary<string, OpenRouterContextService.ModelInfo>? modelInfoMap,
+        Dictionary<string, ModelsDevService.ModelInfo>? modelInfoMap,
         string apiKey, string proxyBaseUrl, bool remove, IReadOnlyCollection<int>? managedPorts = null)
     {
         // Nothing selected and not reverting: leave the file untouched rather
@@ -1121,7 +1121,7 @@ public sealed class AgentConfigurationService
 
     private static IEnumerable<string> BuildGrokModelTable(
         ModelEntry m,
-        Dictionary<string, OpenRouterContextService.ModelInfo>? modelInfoMap,
+        Dictionary<string, ModelsDevService.ModelInfo>? modelInfoMap,
         string apiKey, string proxyBaseUrl)
     {
         // Anthropic models only expose reasoning/thinking through their native
@@ -1149,7 +1149,7 @@ public sealed class AgentConfigurationService
         lines.Add(isAnthropic ? "api_backend = \"messages\"" : "api_backend = \"chat_completions\"");
 
         // Enable Grok's /effort command for models that report reasoning support
-        // (resolved from OpenRouter), mirroring Pi's reasoning flag. We only
+        // (resolved from models.dev), mirroring Pi's reasoning flag. We only
         // declare support and let the user pick the level per session via /effort.
         if (modelInfoMap is not null && modelInfoMap.TryGetValue(m.Id, out var info) && info.SupportsReasoning)
             lines.Add("supports_reasoning_effort = true");

--- a/src/TunnelAgent.Avalonia/Services/ModelPricing.cs
+++ b/src/TunnelAgent.Avalonia/Services/ModelPricing.cs
@@ -25,8 +25,8 @@ public readonly record struct ModelPrice(
 /// <item>OpenAI-style (only an aggregate cached count, input includes it):
 /// <c>max(input-cached,0)*prompt + cached*cacheRead + output*completion</c>.</item>
 /// </list>
-/// Prices come from OpenRouter's live list (cached on disk via
-/// <see cref="OpenRouterContextService"/>) when available, falling back to the
+/// Prices come from models.dev's live catalog (cached on disk via
+/// <see cref="ModelsDevService"/>) when available, falling back to the
 /// built-in table below; unknown models cost 0 (like the proxy's LEFT JOIN with
 /// COALESCE), so the cost figure is a best-effort estimate.
 /// </summary>
@@ -64,7 +64,7 @@ public static class ModelPricing
 
     public static double CostFor(UsageEvent e)
     {
-        if (!TryResolvePrice(e.Model, out var p)) return 0;
+        if (!TryResolvePrice(e.Provider, e.Model, out var p)) return 0;
 
         var cost = e.OutputTokens * p.CompletionPer1M / 1_000_000.0;
 
@@ -90,11 +90,11 @@ public static class ModelPricing
 
     /// <summary>True when at least one event maps to a known price (drives whether cost is shown).</summary>
     public static bool HasKnownPrice(IEnumerable<UsageEvent> events) =>
-        events.Any(e => TryResolvePrice(e.Model, out _));
+        events.Any(e => TryResolvePrice(e.Provider, e.Model, out _));
 
-    /// <summary>OpenRouter live/cached pricing first, then the built-in table.</summary>
-    private static bool TryResolvePrice(string model, out ModelPrice price) =>
-        OpenRouterContextService.Instance.TryGetPrice(model, out price) || TryGetPrice(model, out price);
+    /// <summary>models.dev live/cached pricing first, then the built-in table.</summary>
+    private static bool TryResolvePrice(string? provider, string model, out ModelPrice price) =>
+        ModelsDevService.Instance.TryGetPrice(provider, model, out price) || TryGetPrice(model, out price);
 
     private static bool TryGetPrice(string model, out ModelPrice price)
     {

--- a/src/TunnelAgent.Avalonia/Services/ModelsDevService.cs
+++ b/src/TunnelAgent.Avalonia/Services/ModelsDevService.cs
@@ -13,19 +13,18 @@ namespace TunnelAgent.Services;
 
 /// <summary>
 /// Fetches model metadata (context length, modalities, reasoning support and
-/// list pricing) from OpenRouter's public /v1/models endpoint.
+/// list pricing) from the public models.dev catalog.
 ///
 /// The fetched map is cached in memory for the lifetime of the app and also
 /// persisted to a JSON file under <see cref="IPlatformInfo.LocalDataDirectory"/>.
 /// On startup the disk copy seeds the in-memory cache instantly (works offline);
 /// a background refresh re-fetches from the network only when the disk copy is
-/// missing or older than <see cref="Ttl"/>, so we neither hit OpenRouter on every
-/// launch nor block the UI.
+/// missing or older than <see cref="Ttl"/>, so startup never blocks on models.dev.
 /// </summary>
-public sealed class OpenRouterContextService
+public sealed class ModelsDevService
 {
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(10) };
-    private const string Url = "https://openrouter.ai/api/v1/models";
+    private const string Url = "https://models.dev/api.json";
     private static readonly TimeSpan Ttl = TimeSpan.FromHours(24);
 
     public sealed record ModelInfo(
@@ -43,11 +42,14 @@ public sealed class OpenRouterContextService
     private readonly ConcurrentDictionary<string, ModelPrice?> _priceMemo = new(StringComparer.OrdinalIgnoreCase);
 
     private static string CacheFilePath =>
+        Path.Combine(IPlatformInfo.Current.LocalDataDirectory, "models-dev.json");
+
+    private static string LegacyCacheFilePath =>
         Path.Combine(IPlatformInfo.Current.LocalDataDirectory, "openrouter-models.json");
 
-    public static readonly OpenRouterContextService Instance = new();
+    public static readonly ModelsDevService Instance = new();
 
-    private OpenRouterContextService() { }
+    private ModelsDevService() { }
 
     /// <summary>
     /// Returns model info for a model id, or null if not found.
@@ -62,17 +64,22 @@ public sealed class OpenRouterContextService
 
     /// <summary>
     /// Synchronous price lookup against the already-loaded cache. Returns false when the
-    /// cache is empty (not warmed yet) or the model has no known OpenRouter pricing.
-    /// Safe to call from hot aggregation loops; results are memoized per model id.
+    /// cache is empty (not warmed yet) or the model has no known models.dev pricing.
+    /// Safe to call from hot aggregation loops; results are memoized per provider/model id.
     /// </summary>
-    public bool TryGetPrice(string modelId, out ModelPrice price)
+    public bool TryGetPrice(string modelId, out ModelPrice price) =>
+        TryGetPrice(null, modelId, out price);
+
+    /// <summary>Looks up provider-specific pricing when a provider id is available.</summary>
+    public bool TryGetPrice(string? providerId, string modelId, out ModelPrice price)
     {
         price = default;
         if (string.IsNullOrWhiteSpace(modelId)) return false;
         var map = _cache;
         if (map is null) return false;
 
-        var resolved = _priceMemo.GetOrAdd(modelId, id => Match(map, id)?.Pricing);
+        var memoKey = $"{providerId}\n{modelId}";
+        var resolved = _priceMemo.GetOrAdd(memoKey, _ => Match(map, modelId, providerId)?.Pricing);
         if (resolved is { } p) { price = p; return true; }
         return false;
     }
@@ -80,7 +87,7 @@ public sealed class OpenRouterContextService
     /// <summary>
     /// Synchronously seeds the in-memory cache from the on-disk JSON when present and not
     /// already loaded. Call this before the first cost computation so dashboard figures use
-    /// OpenRouter prices from the start instead of momentarily falling back to the built-in
+    /// models.dev prices from the start instead of momentarily falling back to the built-in
     /// table. Returns true when the cache is populated.
     /// </summary>
     public bool SeedFromDisk()
@@ -115,7 +122,7 @@ public sealed class OpenRouterContextService
         }
     }
 
-    private ModelInfo? Match(Dictionary<string, ModelInfo>? map, string modelId)
+    private ModelInfo? Match(Dictionary<string, ModelInfo>? map, string modelId, string? providerId = null)
     {
         if (map is null) return null;
 
@@ -128,17 +135,25 @@ public sealed class OpenRouterContextService
             Normalize(StripDateSuffix(bare)),
         };
 
-        foreach (var (key, info) in map)
+        ModelInfo? Find(bool requireProvider)
         {
-            if (key.StartsWith('~')) continue;
-            var keyNorm     = Normalize(key);
-            var keyBareNorm = key.Contains('/') ? Normalize(key[(key.LastIndexOf('/') + 1)..]) : keyNorm;
-            if (candidates.Any(c => c.Equals(keyNorm, StringComparison.OrdinalIgnoreCase) ||
-                                    c.Equals(keyBareNorm, StringComparison.OrdinalIgnoreCase)))
-                return info;
+            foreach (var (key, info) in map)
+            {
+                var slash = key.IndexOf('/');
+                var keyProvider = slash > 0 ? key[..slash] : string.Empty;
+                if (requireProvider && !keyProvider.Equals(providerId, StringComparison.OrdinalIgnoreCase)) continue;
+
+                var keyNorm = Normalize(key);
+                var keyBareNorm = slash > 0 ? Normalize(key[(slash + 1)..]) : keyNorm;
+                if (candidates.Any(c => c.Equals(keyNorm, StringComparison.OrdinalIgnoreCase) ||
+                                        c.Equals(keyBareNorm, StringComparison.OrdinalIgnoreCase)))
+                    return info;
+            }
+
+            return null;
         }
 
-        return null;
+        return !string.IsNullOrWhiteSpace(providerId) ? Find(true) ?? Find(false) : Find(false);
     }
 
     private static string Normalize(string id) => id.Replace('.', '-');
@@ -235,6 +250,7 @@ public sealed class OpenRouterContextService
 
             _cache = map;
             _priceMemo.Clear();
+            DeleteLegacyCache();
             var fetchedAt = root?["fetchedAtUtc"]?.GetValue<string>();
             _fetchedAtUtc = DateTime.TryParse(fetchedAt, CultureInfo.InvariantCulture,
                 DateTimeStyles.AdjustToUniversal | DateTimeStyles.AssumeUniversal, out var dt)
@@ -250,29 +266,13 @@ public sealed class OpenRouterContextService
 
     private async Task<bool> FetchAndPersistLockedAsync(CancellationToken ct)
     {
-        using var resp = await Http.GetAsync(Url, ct).ConfigureAwait(false);
+        using var request = new HttpRequestMessage(HttpMethod.Get, Url);
+        request.Headers.UserAgent.ParseAdd("TunnelAgent/1.0");
+        using var resp = await Http.SendAsync(request, ct).ConfigureAwait(false);
         if (!resp.IsSuccessStatusCode) return false;
 
         var body = JsonNode.Parse(await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false));
-        var data = body?["data"]?.AsArray();
-        if (data is null) return false;
-
-        var map = new Dictionary<string, ModelInfo>(StringComparer.OrdinalIgnoreCase);
-        foreach (var item in data)
-        {
-            var id  = item?["id"]?.GetValue<string>();
-            if (id is null) continue;
-            var ctx = item?["context_length"]?.GetValue<int>() ?? 0;
-            var modalities  = item?["architecture"]?["input_modalities"]?.AsArray();
-            var supportsImg = modalities?.Any(m => m?.GetValue<string>() == "image") ?? false;
-            // Reasoning support: OpenRouter exposes a `reasoning` object only for models
-            // that support it, and lists "reasoning" in `supported_parameters`.
-            var supportedParams = item?["supported_parameters"]?.AsArray();
-            var supportsReasoning = item?["reasoning"] is not null
-                || (supportedParams?.Any(p => p?.GetValue<string>() == "reasoning") ?? false);
-            var name = item?["name"]?.GetValue<string>();
-            map[id] = new ModelInfo(ctx, supportsImg, supportsReasoning, name, ReadApiPrice(item?["pricing"]));
-        }
+        var map = ParseCatalog(body);
         if (map.Count == 0) return false;
 
         _cache = map;
@@ -282,34 +282,59 @@ public sealed class OpenRouterContextService
         return true;
     }
 
-    /// <summary>Parse OpenRouter pricing (USD per token, as strings) into per-1M-token rates.</summary>
+    internal static Dictionary<string, ModelInfo> ParseCatalog(JsonNode? body)
+    {
+        var map = new Dictionary<string, ModelInfo>(StringComparer.OrdinalIgnoreCase);
+        if (body is not JsonObject providers) return map;
+
+        foreach (var (providerId, providerNode) in providers)
+        {
+            if (providerNode?["models"] is not JsonObject models) continue;
+            foreach (var (modelId, modelNode) in models)
+            {
+                var ctx = modelNode?["limit"]?["context"]?.GetValue<int>() ?? 0;
+                var modalities = modelNode?["modalities"]?["input"]?.AsArray();
+                var supportsImage = modalities?.Any(m => m?.GetValue<string>() == "image") ?? false;
+                var supportsReasoning = modelNode?["reasoning"]?.GetValue<bool>() ?? false;
+                var name = modelNode?["name"]?.GetValue<string>();
+                map[$"{providerId}/{modelId}"] = new ModelInfo(
+                    ctx,
+                    supportsImage,
+                    supportsReasoning,
+                    name,
+                    ReadApiPrice(modelNode?["cost"]));
+            }
+        }
+
+        return map;
+    }
+
+    /// <summary>Parses models.dev pricing, already expressed in USD per one million tokens.</summary>
     private static ModelPrice? ReadApiPrice(JsonNode? pricing)
     {
         if (pricing is not JsonObject p) return null;
-        var prompt = ParsePerToken(p["prompt"]);
-        var completion = ParsePerToken(p["completion"]);
+        var prompt = ReadNumber(p["input"]);
+        var completion = ReadNumber(p["output"]);
         if (prompt is null && completion is null) return null;
 
-        var promptPer1M = (prompt ?? 0) * 1_000_000.0;
-        var completionPer1M = (completion ?? 0) * 1_000_000.0;
-        // Many models omit a cache-read rate; bill cached tokens as normal input in that case.
-        var cachePer1M = ParsePerToken(p["input_cache_read"]) is { } c ? c * 1_000_000.0 : promptPer1M;
-        // Cache-write (creation) rate; 0 means unknown so CostFor falls back to 1.25× prompt.
-        var cacheWritePer1M = ParsePerToken(p["input_cache_write"]) is { } w ? w * 1_000_000.0 : 0;
+        var promptPer1M = prompt ?? 0;
+        var completionPer1M = completion ?? 0;
+        var cachePer1M = ReadNumber(p["cache_read"]) ?? promptPer1M;
+        var cacheWritePer1M = ReadNumber(p["cache_write"]) ?? 0;
         return new ModelPrice(promptPer1M, completionPer1M, cachePer1M, cacheWritePer1M);
     }
 
-    private static double? ParsePerToken(JsonNode? node)
+    private static double? ReadNumber(JsonNode? node)
     {
         if (node is null) return null;
         try
         {
-            // OpenRouter sends prices as strings, but tolerate numeric JSON too.
             if (node.GetValueKind() == System.Text.Json.JsonValueKind.Number)
                 return node.GetValue<double>();
             var text = node.GetValue<string>();
-            if (string.IsNullOrWhiteSpace(text)) return null;
-            return double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) ? v : null;
+            return double.TryParse(text, NumberStyles.Float, CultureInfo.InvariantCulture, out var value)
+                ? value
+                : null;
         }
         catch
         {
@@ -360,10 +385,23 @@ public sealed class OpenRouterContextService
             var path = CacheFilePath;
             Directory.CreateDirectory(Path.GetDirectoryName(path)!);
             File.WriteAllText(path, root.ToJsonString());
+            DeleteLegacyCache();
         }
         catch
         {
             // Persistence is best-effort; a failed write just means we refetch next launch.
+        }
+    }
+
+    private static void DeleteLegacyCache()
+    {
+        try
+        {
+            File.Delete(LegacyCacheFilePath);
+        }
+        catch
+        {
+            // Best-effort cleanup; retry next time the new cache is loaded or written.
         }
     }
 }

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -406,9 +406,9 @@ SelectedSection is SectionKey.Logs;
         };
         _modelFetch = new TunnelAgent.Services.ModelFetchService(settings);
         _usage = new UsageService(_usageStore);
-        // Seed OpenRouter prices from the on-disk JSON first so the initial cost figures
+        // Seed models.dev prices from the on-disk JSON first so the initial cost figures
         // use real pricing instead of momentarily falling back to the built-in table.
-        TunnelAgent.Services.OpenRouterContextService.Instance.SeedFromDisk();
+        TunnelAgent.Services.ModelsDevService.Instance.SeedFromDisk();
         // Seed telemetry-backed views before logs load, so request_id → provider
         // overrides are available when log entries are parsed.
         var persistedUsage = _usageStore.LoadRecent(50_000);
@@ -2343,12 +2343,12 @@ SelectedSection is SectionKey.Logs;
         await RefreshAllQuotaProvidersAsync();
     }
 
-    // Warm model pricing from disk (instant, offline) then refresh from OpenRouter when
+    // Warm model pricing from disk (instant, offline) then refresh from models.dev when
     // stale, refreshing dashboard cost figures after each step.
     private async Task WarmModelPricingAsync()
     {
         void Refresh() => Dispatcher.UIThread.Post(Dashboard.OnPricingUpdated);
-        await TunnelAgent.Services.OpenRouterContextService.Instance.WarmAsync(Refresh);
+        await TunnelAgent.Services.ModelsDevService.Instance.WarmAsync(Refresh);
     }
 
     private async Task ScanAndRefreshQuotaOnceAsync()
@@ -2830,7 +2830,7 @@ SelectedSection is SectionKey.Logs;
 
     private static async Task<string> ResolveDisplayNameAsync(string modelId, bool isPerplexity)
     {
-        var info = await TunnelAgent.Services.OpenRouterContextService.Instance
+        var info = await TunnelAgent.Services.ModelsDevService.Instance
             .GetModelInfoAsync(modelId).ConfigureAwait(false);
         var name = info?.Name is string n ? StripProviderPrefix(n) : FormatModelId(modelId);
         return isPerplexity ? $"{name} (Tunnel Agent - Perplexity)" : $"{name} (Tunnel Agent)";

--- a/tests/TunnelAgent.Tests/AgentConfigurationServiceTests.cs
+++ b/tests/TunnelAgent.Tests/AgentConfigurationServiceTests.cs
@@ -186,7 +186,7 @@ api_backend = "chat_completions"
             Model("gpt-5.6-sol", "GPT-5.6 Sol"),
             new ModelEntry("claude-sonnet-5", "anthropic", Proxy, "", "Claude Sonnet 5")
         };
-        var metadata = new System.Collections.Generic.Dictionary<string, OpenRouterContextService.ModelInfo>(System.StringComparer.OrdinalIgnoreCase)
+        var metadata = new System.Collections.Generic.Dictionary<string, ModelsDevService.ModelInfo>(System.StringComparer.OrdinalIgnoreCase)
         {
             ["gpt-5.6-sol"] = new(1_050_000, true, true),
             ["claude-sonnet-5"] = new(1_000_000, true, true)

--- a/tests/TunnelAgent.Tests/ModelsDevServiceTests.cs
+++ b/tests/TunnelAgent.Tests/ModelsDevServiceTests.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Nodes;
+using TunnelAgent.Services;
+
+namespace TunnelAgent.Tests;
+
+public sealed class ModelsDevServiceTests
+{
+    [Fact]
+    public void ParseCatalog_ReadsCapabilitiesAndPerMillionPricing()
+    {
+        var catalog = JsonNode.Parse("""
+        {
+          "openai": {
+            "models": {
+              "gpt-test": {
+                "name": "GPT Test",
+                "reasoning": true,
+                "modalities": { "input": ["text", "image"] },
+                "limit": { "context": 200000 },
+                "cost": {
+                  "input": 1.25,
+                  "output": 10,
+                  "cache_read": 0.125,
+                  "cache_write": 1.5
+                }
+              }
+            }
+          }
+        }
+        """);
+
+        var models = ModelsDevService.ParseCatalog(catalog);
+        var model = Assert.Single(models).Value;
+
+        Assert.Equal(200000, model.ContextLength);
+        Assert.True(model.SupportsImage);
+        Assert.True(model.SupportsReasoning);
+        Assert.Equal("GPT Test", model.Name);
+        Assert.Equal(new ModelPrice(1.25, 10, 0.125, 1.5), model.Pricing);
+        Assert.True(models.ContainsKey("openai/gpt-test"));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace OpenRouter model metadata/pricing service with models.dev catalog
- Use provider-specific models.dev pricing for usage cost estimates
- Remove legacy openrouter-models.json cache after new cache loads or writes
- Update docs and tests

## Validation
- dotnet build src/TunnelAgent.Avalonia/TunnelAgent.Avalonia.csproj --no-restore --verbosity quiet
- dotnet test tests/TunnelAgent.Tests/TunnelAgent.Tests.csproj --no-restore --verbosity quiet