### PR TITLE
fix(quota): use Cursor Auto/API and Scoop DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Cursor quota showed the old single spend bar** (`CursorQuotaParser`, `QuotaFetchService`): Cursor Settings now reports **Auto + Composer** and **API** as separate percent buckets (`autoPercentUsed` / `apiPercentUsed`). Quota uses those bars instead of `includedSpend/limit`, keeps on-demand spend when present, and falls back to `/auth/usage` or usage-summary when `planUsage` is missing (Team/Enterprise). Token refresh retries both dashboard calls; parse/network failures surface as a quota error instead of an empty "not loaded" state.
+- **Cursor quota read a stale AppData account** (`CursorStateStore`): Scoop/portable Cursor keeps `state.vscdb` under `data/user-data`, while an older `%APPDATA%\Cursor` install can still contain an expired login. Scan and fetch now pick the newest existing database among AppData, LocalAppData, and Scoop paths.
+
 ## [1.0.6] - 2026-07-27
 
 ### Changed

--- a/src/TunnelAgent.Avalonia/Services/CursorQuotaParser.cs
+++ b/src/TunnelAgent.Avalonia/Services/CursorQuotaParser.cs
@@ -1,0 +1,235 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace TunnelAgent.Services;
+
+internal readonly record struct CursorQuotaBarSpec(
+    string Title,
+    double UsedFraction,
+    DateTimeOffset? ResetsAt);
+
+/// <summary>
+/// Parses Cursor dashboard usage payloads into quota bars.
+/// Pro/Ultra use Auto + Composer and API percents; Team/Enterprise fall back
+/// to request counts or usage-summary meters.
+/// </summary>
+internal static class CursorQuotaParser
+{
+    internal const string AutoTitle = "Auto + Composer";
+    internal const string ApiTitle  = "API";
+
+    internal static string? ParsePlanName(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try
+        {
+            var name = JsonNode.Parse(json)?["planInfo"]?["planName"]?.GetValue<string>();
+            return string.IsNullOrEmpty(name) ? null : name;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    internal static IReadOnlyList<CursorQuotaBarSpec> ParsePeriodUsage(string json)
+    {
+        var doc = ParseObject(json);
+        if (doc is null) return [];
+
+        var reset = ReadTimestamp(doc["billingCycleEnd"]);
+        var bars  = new List<CursorQuotaBarSpec>();
+        var plan  = doc["planUsage"] as JsonObject;
+
+        var autoPct = ReadNumber(plan?["autoPercentUsed"]);
+        var apiPct  = ReadNumber(plan?["apiPercentUsed"]);
+        if (autoPct is not null || apiPct is not null)
+        {
+            if (autoPct is not null)
+                bars.Add(PercentBar(AutoTitle, autoPct.Value, reset));
+            if (apiPct is not null)
+                bars.Add(PercentBar(ApiTitle, apiPct.Value, reset));
+        }
+        else
+        {
+            var used  = ReadNumber(plan?["includedSpend"]) ?? 0;
+            var limit = ReadNumber(plan?["limit"]) ?? 0;
+            if (limit > 0)
+            {
+                bars.Add(new CursorQuotaBarSpec(
+                    $"Included (${FormatCents(used)}/${FormatCents(limit)})",
+                    Clamp01(used / limit),
+                    reset));
+            }
+            else if (ReadNumber(plan?["totalPercentUsed"]) is double pct)
+            {
+                bars.Add(PercentBar("Plan usage", pct, reset));
+            }
+        }
+
+        var spend = doc["spendLimitUsage"] as JsonObject;
+        AddOnDemandBar(bars, spend, reset);
+        return bars;
+    }
+
+    internal static IReadOnlyList<CursorQuotaBarSpec> ParseAuthUsage(string json)
+    {
+        var doc = ParseObject(json);
+        if (doc is null) return [];
+
+        DateTimeOffset? reset = null;
+        if (ReadTimestamp(doc["startOfMonth"]) is DateTimeOffset start)
+            reset = start.AddMonths(1);
+
+        var bucket = doc["gpt-4"] as JsonObject
+                  ?? FindRequestBucket(doc);
+        if (bucket is null) return [];
+
+        var used  = ReadNumber(bucket["numRequests"]) ?? 0;
+        var limit = ReadNumber(bucket["maxRequestUsage"]) ?? 0;
+        if (limit <= 0) return [];
+
+        return
+        [
+            new CursorQuotaBarSpec(
+                $"Included requests ({FormatCount(used)}/{FormatCount(limit)})",
+                Clamp01(used / limit),
+                reset)
+        ];
+    }
+
+    internal static IReadOnlyList<CursorQuotaBarSpec> ParseUsageSummary(string json)
+    {
+        var doc = ParseObject(json);
+        if (doc is null) return [];
+
+        var reset = ReadTimestamp(doc["billingCycleEnd"]);
+        var bars  = new List<CursorQuotaBarSpec>();
+        AddSummaryMeter(bars, "Included", doc["individualUsage"]?["overall"], reset);
+        AddSummaryMeter(bars, "Team", doc["teamUsage"]?["pooled"], reset);
+        AddSummaryMeter(bars, "On-demand", doc["teamUsage"]?["onDemand"], reset);
+        return bars;
+    }
+
+    private static void AddOnDemandBar(List<CursorQuotaBarSpec> bars, JsonObject? spend, DateTimeOffset? reset)
+    {
+        if (spend is null) return;
+
+        var indLimit = ReadNumber(spend["individualLimit"]) ?? 0;
+        var indUsed  = ReadNumber(spend["individualUsed"]) ?? 0;
+        if (indLimit > 0)
+        {
+            bars.Add(new CursorQuotaBarSpec(
+                $"On-demand (${FormatCents(indUsed)}/${FormatCents(indLimit)})",
+                Clamp01(indUsed / indLimit),
+                null));
+            return;
+        }
+
+        var pooledLimit = ReadNumber(spend["pooledLimit"]) ?? 0;
+        var pooledUsed  = ReadNumber(spend["pooledUsed"]) ?? 0;
+        if (pooledLimit > 0)
+        {
+            bars.Add(new CursorQuotaBarSpec(
+                $"On-demand (${FormatCents(pooledUsed)}/${FormatCents(pooledLimit)})",
+                Clamp01(pooledUsed / pooledLimit),
+                reset));
+        }
+    }
+
+    private static void AddSummaryMeter(
+        List<CursorQuotaBarSpec> bars, string label, JsonNode? meter, DateTimeOffset? reset)
+    {
+        if (meter is not JsonObject obj) return;
+        if (obj["enabled"] is JsonValue enabled && enabled.TryGetValue<bool>(out var on) && !on)
+            return;
+
+        var used  = ReadNumber(obj["used"]) ?? 0;
+        var limit = ReadNumber(obj["limit"]) ?? 0;
+        if (limit <= 0) return;
+
+        bars.Add(new CursorQuotaBarSpec(
+            $"{label} ({FormatCount(used)}/{FormatCount(limit)})",
+            Clamp01(used / limit),
+            reset));
+    }
+
+    private static JsonObject? FindRequestBucket(JsonObject doc)
+    {
+        foreach (var kv in doc)
+        {
+            if (kv.Key is "startOfMonth" or "gpt-4") continue;
+            if (kv.Value is JsonObject obj && (ReadNumber(obj["maxRequestUsage"]) ?? 0) > 0)
+                return obj;
+        }
+        return null;
+    }
+
+    private static CursorQuotaBarSpec PercentBar(string title, double percent, DateTimeOffset? reset) =>
+        new(title, Clamp01(percent / 100.0), reset);
+
+    private static JsonObject? ParseObject(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return null;
+        try { return JsonNode.Parse(json) as JsonObject; }
+        catch { return null; }
+    }
+
+    internal static double? ReadNumber(JsonNode? node)
+    {
+        if (node is not JsonValue value) return null;
+
+        if (value.TryGetValue<JsonElement>(out var el))
+        {
+            if (el.ValueKind == JsonValueKind.Number && el.TryGetDouble(out var n) && double.IsFinite(n))
+                return n;
+            if (el.ValueKind == JsonValueKind.String)
+                return ParseNumericString(el.GetString());
+            return null;
+        }
+
+        if (value.TryGetValue<double>(out var d) && double.IsFinite(d)) return d;
+        if (value.TryGetValue<long>(out var l)) return l;
+        if (value.TryGetValue<int>(out var i)) return i;
+        if (value.TryGetValue<decimal>(out var m)) return (double)m;
+        if (value.TryGetValue<string>(out var s)) return ParseNumericString(s);
+        return null;
+    }
+
+    internal static DateTimeOffset? ReadTimestamp(JsonNode? node)
+    {
+        if (node is null) return null;
+
+        if (ReadNumber(node) is double numeric)
+        {
+            var unix = (long)numeric;
+            return unix > 10_000_000_000
+                ? DateTimeOffset.FromUnixTimeMilliseconds(unix)
+                : DateTimeOffset.FromUnixTimeSeconds(unix);
+        }
+
+        if (node is JsonValue value && value.TryGetValue<string>(out var s) &&
+            DateTimeOffset.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var dt))
+            return dt;
+
+        return null;
+    }
+
+    private static double? ParseNumericString(string? s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        return double.TryParse(s, NumberStyles.Float, CultureInfo.InvariantCulture, out var n) && double.IsFinite(n)
+            ? n : null;
+    }
+
+    private static string FormatCents(double cents) =>
+        (cents / 100.0).ToString("0.00", CultureInfo.InvariantCulture);
+
+    private static string FormatCount(double value) =>
+        value.ToString("0", CultureInfo.InvariantCulture);
+
+    private static double Clamp01(double value) => Math.Clamp(value, 0, 1);
+}

--- a/src/TunnelAgent.Avalonia/Services/CursorStateStore.cs
+++ b/src/TunnelAgent.Avalonia/Services/CursorStateStore.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace TunnelAgent.Services;
+
+/// <summary>
+/// Locates Cursor's <c>state.vscdb</c>. Official installs use ApplicationData;
+/// Scoop/portable builds keep user-data next to the app, which can leave a stale
+/// AppData database from an older install.
+/// </summary>
+internal static class CursorStateStore
+{
+    internal static string? ResolveStateDbPath() =>
+        ResolveStateDbPath(EnumerateCandidatePaths());
+
+    internal static string? ResolveStateDbPath(IEnumerable<string> candidates)
+    {
+        string? best = null;
+        var bestTime = DateTime.MinValue;
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate)) continue;
+
+            string full;
+            try { full = Path.GetFullPath(candidate); }
+            catch { continue; }
+
+            if (!seen.Add(full)) continue;
+            if (!File.Exists(full)) continue;
+
+            DateTime mtime;
+            try { mtime = File.GetLastWriteTimeUtc(full); }
+            catch { continue; }
+
+            if (best is null || mtime > bestTime)
+            {
+                best = full;
+                bestTime = mtime;
+            }
+        }
+
+        return best;
+    }
+
+    internal static IEnumerable<string> EnumerateCandidatePaths()
+    {
+        var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+        yield return Path.Combine(appData, "Cursor", "User", "globalStorage", "state.vscdb");
+
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        yield return Path.Combine(localAppData, "Cursor", "User", "globalStorage", "state.vscdb");
+
+        var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        yield return Path.Combine(home, "scoop", "apps", "cursor", "current", "data", "user-data",
+            "User", "globalStorage", "state.vscdb");
+        yield return Path.Combine(home, "scoop", "persist", "cursor", "data", "user-data",
+            "User", "globalStorage", "state.vscdb");
+    }
+}

--- a/src/TunnelAgent.Avalonia/Services/QuotaFetchService.cs
+++ b/src/TunnelAgent.Avalonia/Services/QuotaFetchService.cs
@@ -797,25 +797,25 @@ public sealed class QuotaFetchService
     {
         try
         {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var dbPath  = Path.Combine(appData, "Cursor", "User", "globalStorage", "state.vscdb");
-            if (!File.Exists(dbPath))
+            var dbPath = CursorStateStore.ResolveStateDbPath();
+            if (dbPath is null)
             {
                 SetQuotaError(account, QuotaErrorLocalAuthMissing("Cursor"));
                 return;
             }
 
-            string? accessToken = null, refreshToken = null;
-            using (var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={dbPath};Mode=ReadOnly"))
+            string? accessToken = null, refreshToken = null, email = null;
+            await using (var conn = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={dbPath};Mode=ReadOnly"))
             {
-                conn.Open();
+                await conn.OpenAsync(ct);
                 using var cmd = conn.CreateCommand();
-                cmd.CommandText = "SELECT key, value FROM ItemTable WHERE key IN ('cursorAuth/accessToken','cursorAuth/refreshToken')";
-                using var reader = cmd.ExecuteReader();
-                while (reader.Read())
+                cmd.CommandText = "SELECT key, value FROM ItemTable WHERE key IN ('cursorAuth/accessToken','cursorAuth/refreshToken','cursorAuth/cachedEmail')";
+                await using var reader = await cmd.ExecuteReaderAsync(ct);
+                while (await reader.ReadAsync(ct))
                 {
                     if (reader.GetString(0) == "cursorAuth/accessToken")  accessToken  = reader.GetString(1);
                     if (reader.GetString(0) == "cursorAuth/refreshToken") refreshToken = reader.GetString(1);
+                    if (reader.GetString(0) == "cursorAuth/cachedEmail")  email        = reader.GetString(1);
                 }
             }
 
@@ -825,17 +825,8 @@ public sealed class QuotaFetchService
                 return;
             }
 
-            // Try fetch; if unauthorized, refresh token and retry once
-            var planBody = await CallCursorApiAsync("GetPlanInfo", accessToken, ct);
-            if (planBody is not null)
-            {
-                var planName = JsonNode.Parse(planBody)?["planInfo"]?["planName"]?.GetValue<string>();
-                if (!string.IsNullOrEmpty(planName))
-                    Avalonia.Threading.Dispatcher.UIThread.Post(() => account.PlanBadge = planName);
-            }
-
-            var body = await CallCursorPeriodUsageAsync(accessToken, ct);
-            if (body is null && !string.IsNullOrEmpty(refreshToken))
+            var (planBody, usageBody) = await FetchCursorDashboardAsync(accessToken, ct);
+            if (usageBody is null && !string.IsNullOrEmpty(refreshToken))
             {
                 accessToken = await RefreshCursorTokenAsync(refreshToken, ct);
                 if (string.IsNullOrEmpty(accessToken))
@@ -843,52 +834,89 @@ public sealed class QuotaFetchService
                     SetQuotaError(account, QuotaErrorAuthExpired("Cursor"));
                     return;
                 }
-                body = await CallCursorPeriodUsageAsync(accessToken, ct);
+                (planBody, usageBody) = await FetchCursorDashboardAsync(accessToken, ct);
             }
-            if (body is null)
+            if (usageBody is null)
             {
                 SetQuotaError(account, QuotaErrorRequestFailed("Cursor"));
                 return;
             }
 
-            var doc  = JsonNode.Parse(body);
-            var bars = new List<(string title, double fraction, string resetIn)>();
+            var planName = CursorQuotaParser.ParsePlanName(planBody);
+            var bars = CursorQuotaParser.ParsePeriodUsage(usageBody).ToList();
+            if (bars.Count == 0)
+                bars.AddRange(await FetchCursorUsageFallbacksAsync(accessToken, ct));
 
-            // billingCycleEnd is unix ms as string
-            var cycleEndMs = doc?["billingCycleEnd"]?.GetValue<string>();
-            var resetIn    = cycleEndMs is not null && long.TryParse(cycleEndMs, out var ms)
-                ? FormatResetAtUnix(ms / 1000)
-                : "";
-
-            // planUsage.{includedSpend, limit, totalPercentUsed}
-            var planUsage = doc?["planUsage"];
-            var used      = planUsage?["includedSpend"]?.GetValue<double>() ?? 0;
-            var limit     = planUsage?["limit"]?.GetValue<double>()         ?? 0;
-            if (limit > 0)
-                bars.Add(("Plan usage", Math.Clamp(used / limit, 0, 1), resetIn));
-            else if (planUsage?["totalPercentUsed"]?.GetValue<double>() is double pct && double.IsFinite(pct))
-                bars.Add(("Plan usage", Math.Clamp(pct / 100.0, 0, 1), resetIn));
-
-            // spendLimitUsage — on-demand budget
-            var spend = doc?["spendLimitUsage"];
-            var indLimit = spend?["individualLimit"]?.GetValue<double>() ?? 0;
-            var indUsed  = spend?["individualUsed"]?.GetValue<double>()  ?? 0;
-            if (indLimit > 0)
-                bars.Add(($"On-demand (${indUsed / 100:0.00}/${indLimit / 100:0.00})",
-                    Math.Clamp(indUsed / indLimit, 0, 1), ""));
-
-            Avalonia.Threading.Dispatcher.UIThread.Post(() =>
-            {
-                account.QuotaBars.Clear();
-                foreach (var (title, fraction, ri) in bars)
-                    account.QuotaBars.Add(new QuotaBarViewModel { Title = title, Used = fraction, ResetIn = ri });
-            });
+            ApplyCursorBars(account, planName, email, bars);
         }
-        catch { }
+        catch (OperationCanceledException) { throw; }
+        catch
+        {
+            SetQuotaError(account, QuotaErrorRequestFailed("Cursor"));
+        }
     }
 
-    private static async Task<string?> CallCursorPeriodUsageAsync(string token, CancellationToken ct)
-        => await CallCursorApiAsync("GetCurrentPeriodUsage", token, ct);
+    private static async Task<(string? planBody, string? usageBody)> FetchCursorDashboardAsync(
+        string token, CancellationToken ct)
+    {
+        var planTask  = CallCursorApiAsync("GetPlanInfo", token, ct);
+        var usageTask = CallCursorApiAsync("GetCurrentPeriodUsage", token, ct);
+        return (await planTask, await usageTask);
+    }
+
+    private static async Task<IReadOnlyList<CursorQuotaBarSpec>> FetchCursorUsageFallbacksAsync(
+        string token, CancellationToken ct)
+    {
+        var authUsage = await CallCursorGetAsync("https://api2.cursor.sh/auth/usage", token, ct);
+        if (authUsage is not null)
+        {
+            var bars = CursorQuotaParser.ParseAuthUsage(authUsage);
+            if (bars.Count > 0) return bars;
+        }
+
+        foreach (var url in new[]
+                 {
+                     "https://api2.cursor.sh/api/usage-summary",
+                     "https://api2.cursor.sh/api/usage/summary",
+                     "https://cursor.com/api/usage-summary",
+                 })
+        {
+            var summary = await CallCursorGetAsync(url, token, ct);
+            if (summary is null) continue;
+            var bars = CursorQuotaParser.ParseUsageSummary(summary);
+            if (bars.Count > 0) return bars;
+        }
+
+        return [];
+    }
+
+    private static void ApplyCursorBars(
+        ProviderAccountViewModel account, string? planName, string? email, IReadOnlyList<CursorQuotaBarSpec> bars)
+    {
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            if (!string.IsNullOrEmpty(planName))
+                account.PlanBadge = planName;
+            if (!string.IsNullOrEmpty(email))
+            {
+                account.Email = email;
+                account.Label = email;
+            }
+
+            account.QuotaError = "";
+            account.QuotaBars.Clear();
+            foreach (var bar in bars)
+            {
+                account.QuotaBars.Add(new QuotaBarViewModel
+                {
+                    Title   = bar.Title,
+                    Used    = bar.UsedFraction,
+                    ResetIn = FormatResetAt(bar.ResetsAt),
+                });
+            }
+            account.QuotaFetchedEmpty = bars.Count == 0;
+        });
+    }
 
     private static async Task<string?> CallCursorApiAsync(string method, string token, CancellationToken ct)
     {
@@ -900,6 +928,20 @@ public sealed class QuotaFetchService
         using var resp = await Http.SendAsync(req, ct);
         if (!resp.IsSuccessStatusCode) return null;
         return await resp.Content.ReadAsStringAsync(ct);
+    }
+
+    private static async Task<string?> CallCursorGetAsync(string url, string token, CancellationToken ct)
+    {
+        try
+        {
+            using var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Add("Authorization", $"Bearer {token}");
+            using var resp = await Http.SendAsync(req, ct);
+            if (!resp.IsSuccessStatusCode) return null;
+            return await resp.Content.ReadAsStringAsync(ct);
+        }
+        catch (OperationCanceledException) { throw; }
+        catch { return null; }
     }
 
     private static async Task<string?> RefreshCursorTokenAsync(string refreshToken, CancellationToken ct)
@@ -1635,6 +1677,12 @@ public sealed class QuotaFetchService
         if (string.IsNullOrWhiteSpace(raw)) return raw;
         return string.Join(" ", raw.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries)
             .Select(w => char.ToUpperInvariant(w[0]) + w[1..].ToLowerInvariant()));
+    }
+
+    private static string FormatResetAt(DateTimeOffset? at)
+    {
+        if (at is null) return "";
+        return FormatDiff(at.Value - DateTimeOffset.UtcNow);
     }
 
     private static string FormatResetAtUnix(long? unixSeconds)

--- a/src/TunnelAgent.Avalonia/Services/QuotaProviderService.cs
+++ b/src/TunnelAgent.Avalonia/Services/QuotaProviderService.cs
@@ -40,9 +40,8 @@ public sealed class QuotaProviderService
     {
         try
         {
-            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-            var dbPath  = Path.Combine(appData, "Cursor", "User", "globalStorage", "state.vscdb");
-            if (!File.Exists(dbPath)) return NotDetected;
+            var dbPath = CursorStateStore.ResolveStateDbPath();
+            if (dbPath is null) return NotDetected;
 
             string? accessToken = null, refreshToken = null, email = null, planType = null;
             await using var conn = new SqliteConnection($"Data Source={dbPath};Mode=ReadOnly");

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -1618,6 +1618,7 @@ SelectedSection is SectionKey.Logs;
         IsRefreshingAllQuotaProviders = true;
         try
         {
+            await ScanQuotaProvidersAsync();
             foreach (var account in QuotaProviders.SelectMany(QuotaAccountsFor).ToList())
                 await RefreshQuotaAsync(account);
         }
@@ -2339,7 +2340,6 @@ SelectedSection is SectionKey.Logs;
 
     private async Task ScanAndRefreshQuotaAsync()
     {
-        await ScanQuotaProvidersAsync();
         await RefreshAllQuotaProvidersAsync();
     }
 

--- a/src/TunnelAgent.Avalonia/ViewModels/ProviderViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/ProviderViewModel.cs
@@ -78,6 +78,7 @@ public partial class ProviderAccountViewModel : ViewModelBase
 
     /// <summary>Email or username shown in the expanded account row.</summary>
     [ObservableProperty] private string _email = "";
+    partial void OnEmailChanged(string value) => OnPropertyChanged(nameof(DisplayName));
 
     /// <summary>Plan badge text, e.g. "PLUS", "PRO", "FREE". Empty = hide badge.</summary>
     [ObservableProperty] private string _planBadge = "";

--- a/tests/TunnelAgent.Tests/CursorQuotaParserTests.cs
+++ b/tests/TunnelAgent.Tests/CursorQuotaParserTests.cs
@@ -1,0 +1,167 @@
+using TunnelAgent.Services;
+
+namespace TunnelAgent.Tests;
+
+public sealed class CursorQuotaParserTests
+{
+    [Fact]
+    public void ParsePeriodUsage_WithAutoAndApiPercents_ReturnsThoseBarsNotIncludedSpend()
+    {
+        var json = """
+            {
+              "billingCycleEnd": "1771077734000",
+              "planUsage": {
+                "includedSpend": 1288,
+                "limit": 2000,
+                "autoPercentUsed": 3.9,
+                "apiPercentUsed": 2.6,
+                "totalPercentUsed": 3.7
+              }
+            }
+            """;
+
+        var bars = CursorQuotaParser.ParsePeriodUsage(json);
+
+        Assert.Equal(2, bars.Count);
+        Assert.Equal(CursorQuotaParser.AutoTitle, bars[0].Title);
+        Assert.Equal(0.039, bars[0].UsedFraction, 3);
+        Assert.Equal(CursorQuotaParser.ApiTitle, bars[1].Title);
+        Assert.Equal(0.026, bars[1].UsedFraction, 3);
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1771077734000), bars[0].ResetsAt);
+        Assert.Equal(bars[0].ResetsAt, bars[1].ResetsAt);
+    }
+
+    [Fact]
+    public void ParsePeriodUsage_WithoutPercents_FallsBackToIncludedSpendDollars()
+    {
+        var json = """
+            {
+              "planUsage": { "includedSpend": 23222, "limit": 40000 }
+            }
+            """;
+
+        var bar = Assert.Single(CursorQuotaParser.ParsePeriodUsage(json));
+
+        Assert.Equal("Included ($232.22/$400.00)", bar.Title);
+        Assert.Equal(0.58055, bar.UsedFraction, 5);
+        Assert.Null(bar.ResetsAt);
+    }
+
+    [Fact]
+    public void ParsePeriodUsage_BillingCycleEndRfc3339_SetsReset()
+    {
+        var json = """
+            {
+              "billingCycleEnd": "2026-09-01T00:00:00.000Z",
+              "planUsage": { "autoPercentUsed": 10, "apiPercentUsed": 20 }
+            }
+            """;
+
+        var bars = CursorQuotaParser.ParsePeriodUsage(json);
+
+        Assert.Equal(DateTimeOffset.Parse("2026-09-01T00:00:00.000Z"), bars[0].ResetsAt);
+    }
+
+    [Fact]
+    public void ParsePeriodUsage_BillingCycleEndUnixMsNumber_SetsReset()
+    {
+        var json = """
+            {
+              "billingCycleEnd": 1771077734000,
+              "planUsage": { "autoPercentUsed": 1, "apiPercentUsed": 2 }
+            }
+            """;
+
+        var bars = CursorQuotaParser.ParsePeriodUsage(json);
+
+        Assert.Equal(DateTimeOffset.FromUnixTimeMilliseconds(1771077734000), bars[0].ResetsAt);
+    }
+
+    [Fact]
+    public void ParsePeriodUsage_OnDemandIndividualLimit_AddsOnDemandBar()
+    {
+        var json = """
+            {
+              "planUsage": { "autoPercentUsed": 0, "apiPercentUsed": 0 },
+              "spendLimitUsage": { "individualLimit": 10000, "individualUsed": 2500 }
+            }
+            """;
+
+        var bars = CursorQuotaParser.ParsePeriodUsage(json);
+
+        Assert.Equal(3, bars.Count);
+        var onDemand = bars[2];
+        Assert.Equal("On-demand ($25.00/$100.00)", onDemand.Title);
+        Assert.Equal(0.25, onDemand.UsedFraction);
+        Assert.Null(onDemand.ResetsAt);
+    }
+
+    [Fact]
+    public void ParsePeriodUsage_EmptyPlanUsage_ReturnsNoBars()
+    {
+        var json = """
+            { "billingCycleStart": "1772124774973", "billingCycleEnd": "1772124774973", "displayThreshold": 100 }
+            """;
+
+        Assert.Empty(CursorQuotaParser.ParsePeriodUsage(json));
+    }
+
+    [Fact]
+    public void ParsePeriodUsage_InvalidJson_ReturnsNoBars()
+    {
+        Assert.Empty(CursorQuotaParser.ParsePeriodUsage("{not-json"));
+        Assert.Empty(CursorQuotaParser.ParsePeriodUsage(""));
+    }
+
+    [Fact]
+    public void ParseAuthUsage_Gpt4RequestCap_ReturnsIncludedRequestsBar()
+    {
+        var json = """
+            {
+              "gpt-4": {
+                "numRequests": 39,
+                "maxRequestUsage": 500
+              },
+              "startOfMonth": "2026-02-09T17:36:37.000Z"
+            }
+            """;
+
+        var bar = Assert.Single(CursorQuotaParser.ParseAuthUsage(json));
+
+        Assert.Equal("Included requests (39/500)", bar.Title);
+        Assert.Equal(39.0 / 500.0, bar.UsedFraction, 5);
+        Assert.Equal(DateTimeOffset.Parse("2026-03-09T17:36:37.000Z"), bar.ResetsAt);
+    }
+
+    [Fact]
+    public void ParseUsageSummary_IndividualAndTeam_ReturnsBars()
+    {
+        var json = """
+            {
+              "billingCycleEnd": "2026-08-01T00:00:00.000Z",
+              "individualUsage": { "overall": { "enabled": true, "used": 71, "limit": 10000 } },
+              "teamUsage": {
+                "pooled": { "enabled": true, "used": 3479810, "limit": 60000000 },
+                "onDemand": { "enabled": true, "used": 0, "limit": 5000000 }
+              }
+            }
+            """;
+
+        var bars = CursorQuotaParser.ParseUsageSummary(json);
+
+        Assert.Equal(3, bars.Count);
+        Assert.Equal("Included (71/10000)", bars[0].Title);
+        Assert.Equal(71.0 / 10000.0, bars[0].UsedFraction, 5);
+        Assert.Equal("Team (3479810/60000000)", bars[1].Title);
+        Assert.Equal("On-demand (0/5000000)", bars[2].Title);
+        Assert.Equal(DateTimeOffset.Parse("2026-08-01T00:00:00.000Z"), bars[0].ResetsAt);
+    }
+
+    [Fact]
+    public void ParsePlanName_ReadsPlanInfoPlanName()
+    {
+        Assert.Equal("Pro", CursorQuotaParser.ParsePlanName("""{"planInfo":{"planName":"Pro"}}"""));
+        Assert.Null(CursorQuotaParser.ParsePlanName("""{"planInfo":{}}"""));
+        Assert.Null(CursorQuotaParser.ParsePlanName(null));
+    }
+}

--- a/tests/TunnelAgent.Tests/CursorStateStoreTests.cs
+++ b/tests/TunnelAgent.Tests/CursorStateStoreTests.cs
@@ -1,0 +1,56 @@
+using TunnelAgent.Services;
+
+namespace TunnelAgent.Tests;
+
+public sealed class CursorStateStoreTests
+{
+    [Fact]
+    public void ResolveStateDbPath_WhenNoneExist_ReturnsNull()
+    {
+        using var temp = new TestTempDirectory();
+        var missing = Path.Combine(temp.Path, "nope", "state.vscdb");
+
+        Assert.Null(CursorStateStore.ResolveStateDbPath(new[] { missing }));
+    }
+
+    [Fact]
+    public void ResolveStateDbPath_PicksNewestExistingFile()
+    {
+        using var temp = new TestTempDirectory();
+        var stale = temp.File("stale.vscdb");
+        var live  = temp.File("live.vscdb");
+        File.WriteAllText(stale, "old");
+        File.WriteAllText(live, "new");
+        File.SetLastWriteTimeUtc(stale, DateTime.UtcNow.AddDays(-60));
+        File.SetLastWriteTimeUtc(live, DateTime.UtcNow);
+
+        var resolved = CursorStateStore.ResolveStateDbPath(new[] { stale, live });
+
+        Assert.Equal(Path.GetFullPath(live), resolved);
+    }
+
+    [Fact]
+    public void ResolveStateDbPath_SkipsMissingThenUsesExisting()
+    {
+        using var temp = new TestTempDirectory();
+        var missing = Path.Combine(temp.Path, "missing.vscdb");
+        var present = temp.File("present.vscdb");
+        File.WriteAllText(present, "ok");
+
+        var resolved = CursorStateStore.ResolveStateDbPath(new[] { missing, present });
+
+        Assert.Equal(Path.GetFullPath(present), resolved);
+    }
+
+    [Fact]
+    public void ResolveStateDbPath_DeduplicatesSamePath()
+    {
+        using var temp = new TestTempDirectory();
+        var db = temp.File("state.vscdb");
+        File.WriteAllText(db, "ok");
+
+        var resolved = CursorStateStore.ResolveStateDbPath(new[] { db, db });
+
+        Assert.Equal(Path.GetFullPath(db), resolved);
+    }
+}


### PR DESCRIPTION
## Summary
- Show Cursor Settings Auto + Composer and API percent bars instead of the old single spend pool.
- Prefer the newest `state.vscdb` (Scoop/portable user-data over a stale AppData login) and refresh the displayed email on quota scan.
- Fall back to `/auth/usage` or usage-summary when `planUsage` is missing (Team/Enterprise), and surface fetch errors instead of an empty not-loaded state.

## Test plan
- [ ] Restart Tunnel Agent with Scoop Cursor signed in; Quota Cursor shows the current account, not the expired AppData one.
- [ ] Confirm Auto + Composer and API bars match Cursor Settings percentages.
- [ ] Refresh Quota after switching Cursor accounts; email and bars update.
- [ ] `dotnet test tests/TunnelAgent.Tests/TunnelAgent.Tests.csproj --filter FullyQualifiedName~Cursor`

Made with [Cursor](https://cursor.com)