### PR TITLE
feat: register 9Router as a managed engine

### DIFF
--- a/src/TunnelAgent.Infrastructure/Engine/EngineRegistryService.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/EngineRegistryService.cs
@@ -6,6 +6,7 @@ using TunnelAgent.Core.Engine;
 using TunnelAgent.Services;
 using CliProxyEngineService = TunnelAgent.Infrastructure.Engine.CliProxy.EngineService;
 using PerplexityEngineService = TunnelAgent.Infrastructure.Engine.Perplexity.EngineService;
+using NineRouterEngineService = TunnelAgent.Infrastructure.Engine.NineRouter.EngineService;
 
 namespace TunnelAgent.Infrastructure.Engine;
 
@@ -19,7 +20,8 @@ public sealed class EngineRegistryService
         var engines = new IManagedEngine[]
         {
             new CliProxyEngineService(settings),
-            new PerplexityEngineService(settings)
+            new PerplexityEngineService(settings),
+            new NineRouterEngineService(settings)
         };
 
         _engines = engines.ToDictionary(e => e.Definition.Id, StringComparer.OrdinalIgnoreCase);

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/DownloadService.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/DownloadService.cs
@@ -140,6 +140,12 @@ public sealed class DownloadService
     /// <summary>Gets whether this instance's engine directory contains a 9Router server entry file.</summary>
     public bool IsInstalled => FindServerEntry(EngineDir) is not null;
 
+    /// <summary>
+    /// Gets the extracted standalone server path (<c>app/custom-server.js</c> or <c>app/server.js</c>)
+    /// in <see cref="EngineDir"/>, or <see langword="null"/> when the engine is not installed.
+    /// </summary>
+    public string? ServerEntryPath => FindServerEntry(EngineDir);
+
     /// <summary>Loads install metadata from disk and sets <see cref="State"/> to stopped or not installed.</summary>
     public async Task InitializeAsync()
     {

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/EngineService.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/EngineService.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using TunnelAgent.Core.Engine;
+using TunnelAgent.Services;
+
+namespace TunnelAgent.Infrastructure.Engine.NineRouter;
+
+/// <summary>
+/// Managed engine implementation for 9Router. Composes
+/// <see cref="DownloadService"/>, <see cref="ProcessService"/>, and
+/// <see cref="SettingsService"/> into a single <see cref="IManagedEngine"/> surface.
+/// </summary>
+public sealed class EngineService : IManagedEngine
+{
+    private readonly DownloadService _download;
+    private readonly ProcessService _process;
+    private readonly SettingsService _settings;
+    private readonly SemaphoreSlim _updateLock = new(1, 1);
+    private string? _cannotStartError;
+
+    /// <inheritdoc />
+    public EngineDefinition Definition { get; } = EngineCatalog.NineRouter;
+
+    /// <inheritdoc />
+    public EngineState State { get; private set; } = EngineState.NotInstalled;
+
+    /// <inheritdoc />
+    public string? InstalledVersion => _download.InstalledVersion;
+
+    /// <inheritdoc />
+    public string? LatestVersion => _download.LatestVersion;
+
+    /// <inheritdoc />
+    public string? InstalledBinarySha256 => _download.InstalledBinarySha256;
+
+    /// <inheritdoc />
+    public string? InstalledArchiveSha256 => _download.InstalledArchiveSha256;
+
+    /// <inheritdoc />
+    public string? LatestAssetName => _download.LatestAssetName;
+
+    /// <inheritdoc />
+    public string? LatestAssetSha256 => _download.LatestAssetSha256;
+
+    /// <inheritdoc />
+    public string? IntegrityError => _download.IntegrityError;
+
+    /// <inheritdoc />
+    public bool UpdateAvailable => _download.UpdateAvailable;
+
+    /// <inheritdoc />
+    public double DownloadProgress => _download.DownloadProgress;
+
+    /// <inheritdoc />
+    public bool IsRunning => _process.IsRunning;
+
+    /// <inheritdoc />
+    public int Port => GetRuntimeSettings().Port;
+
+    /// <inheritdoc />
+    public string? LastError => _cannotStartError ?? _download.IntegrityError ?? _process.LastError;
+
+    /// <inheritdoc />
+    public EngineErrorKind LastErrorKind => _cannotStartError is not null
+        ? EngineErrorKind.LaunchFailed
+        : _download.IntegrityError is not null ? EngineErrorKind.None : _process.LastErrorKind;
+
+    /// <inheritdoc />
+    public event EventHandler? StateChanged;
+
+    /// <summary>Creates a 9Router engine that installs into the default local-data directory.</summary>
+    /// <param name="settings">Persisted app settings used for the engine port and preferred version.</param>
+    public EngineService(SettingsService settings)
+    {
+        _settings = settings;
+        _download = new DownloadService();
+        _process = new ProcessService();
+
+        _download.StateChanged += OnSubStateChanged;
+        _process.StateChanged += OnSubStateChanged;
+    }
+
+    /// <inheritdoc />
+    public async Task InitializeAsync()
+    {
+        await _download.InitializeAsync();
+
+        if (!DownloadService.IsBinaryInstalled())
+        {
+            await _download.CheckForUpdateAsync();
+            try { await _download.DownloadAndInstallAsync(); }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[NineRouter.EngineService] Download failed: {ex.Message}");
+                return;
+            }
+        }
+        else if (_settings.Current.AutoCheckForUpdates)
+            _ = _download.CheckForUpdateAsync();
+    }
+
+    /// <summary>
+    /// Starts the 9Router Node.js server when the package is installed and Node.js is available.
+    /// Returns without throwing when the engine is not installed or Node.js cannot be detected.
+    /// </summary>
+    /// <param name="ct">Token used to cancel the process health-check wait.</param>
+    public async Task StartAsync(CancellationToken ct = default)
+    {
+        if (!DownloadService.IsBinaryInstalled()) return;
+
+        var node = new NodeRuntimeDetector().Detect();
+        if (node is null)
+        {
+            _cannotStartError = DownloadService.NodeRequiredMessage;
+            State = EngineState.Error;
+            StateChanged?.Invoke(this, EventArgs.Empty);
+            return;
+        }
+
+        var serverEntryPath = _download.ServerEntryPath;
+        if (serverEntryPath is null) return;
+
+        _cannotStartError = null;
+        await _process.StartAsync(node.ExecutablePath, serverEntryPath, Port, ct);
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync() => _process.StopAsync();
+
+    /// <summary>No-op: 9Router persists configuration in SQLite and HTTP, not a file Tunnel Agent writes.</summary>
+    public Task WriteConfigAsync() => Task.CompletedTask;
+
+    /// <inheritdoc />
+    public Task CheckForUpdateAsync() => _download.CheckForUpdateAsync();
+
+    /// <inheritdoc />
+    public Task<IReadOnlyList<EngineReleaseInfo>> ListReleasesAsync(int limit = 30) =>
+        _download.ListReleasesAsync(limit);
+
+    /// <inheritdoc />
+    public Task PrepareVersionAsync(string version) => _download.PrepareVersionAsync(version);
+
+    /// <inheritdoc />
+    public Task DownloadAndInstallAsync() => DownloadAndInstallAsync(GetPreferredVersionOrNull());
+
+    /// <inheritdoc />
+    public async Task DownloadAndInstallAsync(string? version)
+    {
+        await _updateLock.WaitAsync();
+        try
+        {
+            var wasRunning = IsRunning;
+            if (wasRunning) await StopAsync();
+
+            await _download.DownloadAndInstallAsync(string.IsNullOrWhiteSpace(version) ? GetPreferredVersionOrNull() : version);
+
+            if (wasRunning) await StartAsync();
+        }
+        finally
+        {
+            _updateLock.Release();
+        }
+    }
+
+    private string? GetPreferredVersionOrNull()
+    {
+        var preferred = GetRuntimeSettings().PreferredVersion;
+        return string.IsNullOrWhiteSpace(preferred) ? null : preferred;
+    }
+
+    private void OnSubStateChanged(object? sender, EventArgs e)
+    {
+        State = _process.State switch
+        {
+            EngineState.Running or EngineState.Starting or EngineState.Error => _process.State,
+            _ => _download.State
+        };
+
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private EngineRuntimeSettings GetRuntimeSettings() =>
+        _settings.Current.GetOrAddEngine(Definition.Id, Definition.DefaultPort);
+}

--- a/tests/TunnelAgent.Tests/EngineRegistryAndPerplexityTests.cs
+++ b/tests/TunnelAgent.Tests/EngineRegistryAndPerplexityTests.cs
@@ -24,7 +24,7 @@ public sealed class EngineRegistryAndPerplexityTests
     }
 
     [Fact]
-    public async Task EngineRegistryService_ExposesBothManagedEngines()
+    public async Task EngineRegistryService_ExposesAllManagedEngines()
     {
         using var temp = new TestTempDirectory();
         var settings = new SettingsService(temp.File("settings.json"));
@@ -32,9 +32,10 @@ public sealed class EngineRegistryAndPerplexityTests
 
         var registry = new EngineRegistryService(settings);
 
-        Assert.Equal(2, registry.Engines.Count);
+        Assert.Equal(3, registry.Engines.Count);
         Assert.IsType<TunnelAgent.Infrastructure.Engine.CliProxy.EngineService>(registry.Get("cliproxyapi"));
         Assert.IsType<TunnelAgent.Infrastructure.Engine.Perplexity.EngineService>(registry.Get("perplexity-webui-scraper"));
+        Assert.IsType<TunnelAgent.Infrastructure.Engine.NineRouter.EngineService>(registry.Get("9router"));
     }
 
     [Fact]

--- a/tests/TunnelAgent.Tests/NineRouterEngineServiceTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterEngineServiceTests.cs
@@ -1,0 +1,112 @@
+using TunnelAgent.Services;
+using Xunit;
+
+using TunnelAgent.Core.Engine;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+namespace TunnelAgent.Tests;
+
+public sealed class NineRouterEngineServiceTests
+{
+    [Fact]
+    public async Task Constructor_InitialState_IsNotInstalledOrStopped()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+
+        Assert.Contains(engine.State, new[] { EngineState.NotInstalled, EngineState.Stopped });
+        Assert.False(engine.IsRunning);
+        Assert.False(engine.UpdateAvailable);
+        Assert.Equal(0, engine.DownloadProgress);
+        Assert.Null(engine.InstalledVersion);
+        Assert.Null(engine.LatestVersion);
+    }
+
+    [Fact]
+    public async Task StateChanged_RaisesWhenStateChanges()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+        var raised = false;
+        engine.StateChanged += (_, _) => raised = true;
+
+        try { await engine.InitializeAsync(); } catch { }
+
+        Assert.True(raised);
+    }
+
+    [Fact]
+    public async Task StopAsync_WhenNotRunning_DoesNotThrow()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+
+        await engine.StopAsync();
+    }
+
+    [Fact]
+    public async Task WriteConfigAsync_DoesNotThrow()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+
+        var engine = new EngineService(settings);
+        await engine.WriteConfigAsync();
+    }
+
+    [Fact]
+    public async Task CheckForUpdateAsync_DoesNotThrow()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+
+        try { await engine.CheckForUpdateAsync(); } catch { }
+    }
+
+    [Fact]
+    public async Task InstalledVersion_ReflectsDownloadService()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+
+        Assert.Null(engine.InstalledVersion);
+        Assert.Equal(20128, engine.Port);
+        Assert.Null(engine.LastError);
+    }
+
+    [Fact]
+    public async Task DownloadAndInstallAsync_NotInstalled_PropagatesExceptions()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+
+        await Assert.ThrowsAnyAsync<Exception>(() => engine.DownloadAndInstallAsync("v0.0.0-nonexistent"));
+    }
+
+    [Fact]
+    public async Task Properties_ExposeSubserviceState()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var engine = new EngineService(settings);
+
+        Assert.Null(engine.InstalledBinarySha256);
+        Assert.Null(engine.InstalledArchiveSha256);
+        Assert.Null(engine.LatestAssetName);
+        Assert.Null(engine.LatestAssetSha256);
+        Assert.Null(engine.IntegrityError);
+    }
+}


### PR DESCRIPTION
Compose download and process services so Tunnel Agent can install, start, and update 9Router like Perplexity.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>