### PR TITLE
feat: add 9Router configuration tab

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -772,6 +772,9 @@
   <data name="ConfigView_TabPerplexity" xml:space="preserve">
     <value>Perplexity</value>
   </data>
+  <data name="ConfigView_TabNineRouter" xml:space="preserve">
+    <value>9Router</value>
+  </data>
 
   <data name="ConfigView_General_Title" xml:space="preserve">
     <value>General</value>
@@ -1031,6 +1034,66 @@
   </data>
 
   <!-- ═══════════════════════════════════════════════════════════════════════════
+       CONFIGURATION VIEW - 9ROUTER
+       ═══════════════════════════════════════════════════════════════════════════ -->
+  <data name="ConfigView_NineRouter_Title" xml:space="preserve">
+    <value>9Router</value>
+  </data>
+  <data name="ConfigView_NineRouter_Subtitle" xml:space="preserve">
+    <value>Engine version, port, and Node.js requirements.</value>
+  </data>
+  <data name="ConfigView_NineRouter_UpdateSuccess" xml:space="preserve">
+    <value>Successfully updated to {0}</value>
+  </data>
+
+  <data name="ConfigView_NineRouter_Engine_Label" xml:space="preserve">
+    <value>9Router</value>
+  </data>
+  <data name="ConfigView_NineRouter_Engine_Installed" xml:space="preserve">
+    <value>Installed: {0}</value>
+  </data>
+  <data name="ConfigView_NineRouter_Engine_Available" xml:space="preserve">
+    <value>{0} available</value>
+  </data>
+  <data name="ConfigView_NineRouter_Engine_Check" xml:space="preserve">
+    <value>Check</value>
+  </data>
+  <data name="ConfigView_NineRouter_Engine_UpdateNow" xml:space="preserve">
+    <value>Update now</value>
+  </data>
+
+  <data name="ConfigView_NineRouter_EngineFolder_Label" xml:space="preserve">
+    <value>Engine install folder</value>
+  </data>
+  <data name="ConfigView_NineRouter_EngineFolder_Description" xml:space="preserve">
+    <value>Downloaded 9Router files are stored in the local engine directory.</value>
+  </data>
+  <data name="ConfigView_NineRouter_EngineFolder_Open" xml:space="preserve">
+    <value>Open Folder</value>
+  </data>
+  <data name="ConfigView_NineRouter_Dashboard_Label" xml:space="preserve">
+    <value>Dashboard</value>
+  </data>
+  <data name="ConfigView_NineRouter_Dashboard_Description" xml:space="preserve">
+    <value>Opens the local 9Router dashboard in your browser.</value>
+  </data>
+  <data name="ConfigView_NineRouter_Dashboard_Open" xml:space="preserve">
+    <value>Open</value>
+  </data>
+  <data name="ConfigView_NineRouter_ListenPort_Label" xml:space="preserve">
+    <value>Listen port</value>
+  </data>
+  <data name="ConfigView_NineRouter_ListenPort_Description" xml:space="preserve">
+    <value>Localhost only. Restart required to apply.</value>
+  </data>
+  <data name="ConfigView_NineRouter_ListenPort_Reset" xml:space="preserve">
+    <value>Reset</value>
+  </data>
+  <data name="ConfigView_NineRouter_NodeMissing" xml:space="preserve">
+    <value>Node.js 18 or later is required to run 9Router. Install Node and restart Tunnel Agent.</value>
+  </data>
+
+  <!-- ═══════════════════════════════════════════════════════════════════════════
        MISCELLANEOUS
        ═══════════════════════════════════════════════════════════════════════════ -->
   <data name="Toast_NoUpdateAvailable" xml:space="preserve">
@@ -1249,6 +1312,9 @@
   </data>
   <data name="Provider_perplexity-webui-scraper_Description" xml:space="preserve">
     <value>OpenAI-compatible local API backed by Perplexity WebUI sessions.</value>
+  </data>
+  <data name="Provider_9router_Description" xml:space="preserve">
+    <value>OpenAI-compatible local router for 40+ providers with auto-fallback.</value>
   </data>
   <data name="ProvidersView_Provider_ConnectedAccountSingular" xml:space="preserve">
     <value>{0} connected account</value>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ using TunnelAgent.Core.Engine;
 using TunnelAgent.Infrastructure.Engine;
 using TunnelAgent.Infrastructure.Engine.CliProxy;
 using TunnelAgent.Infrastructure.Engine.Perplexity;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
 
 namespace TunnelAgent.ViewModels;
 
@@ -178,6 +179,8 @@ SelectedSection is SectionKey.Logs;
     [ObservableProperty] private bool _showUpdateSuccess;
     [ObservableProperty] private bool _showCliProxyUpdateSuccess;
     [ObservableProperty] private bool _showPerplexityUpdateSuccess;
+    [ObservableProperty] private bool _showNineRouterUpdateSuccess;
+    [ObservableProperty] private bool _isNineRouterNodeMissing;
     [ObservableProperty] private string _engineStatusText = "Stopped";
 
     [ObservableProperty] private bool _showAddAccountDialog;
@@ -459,6 +462,7 @@ SelectedSection is SectionKey.Logs;
     {
         SectionKey.ConfigCliProxy => 1,
         SectionKey.ConfigPerplexity => 2,
+        SectionKey.ConfigNineRouter => 3,
         _ => 0
     };
     public int QuotaTabIndex =>
@@ -477,6 +481,7 @@ SelectedSection is SectionKey.Logs;
     {
         "cliproxyapi" => _localization.GetString("Provider_cliproxyapi_Description"),
         "perplexity-webui-scraper" => _localization.GetString("Provider_perplexity-webui-scraper_Description"),
+        "9router" => _localization.GetString("Provider_9router_Description"),
         _ => FocusedConfigEngine.Definition.Description,
     };
     public string EndpointUrl => $"http://127.0.0.1:{Port}";
@@ -584,6 +589,7 @@ SelectedSection is SectionKey.Logs;
     private IManagedEngine FocusedConfigEngine => _engineRegistry.Get(FocusedConfigEngineId);
     private IManagedEngine CliProxyEngine => _engineRegistry.Get(EngineCatalog.CliProxyApi.Id);
     private IManagedEngine PerplexityEngine => _engineRegistry.Get(EngineCatalog.PerplexityWebUiScraper.Id);
+    private IManagedEngine NineRouterEngine => _engineRegistry.Get(EngineCatalog.NineRouter.Id);
 
     public bool EngineAutoStart
     {
@@ -865,6 +871,15 @@ SelectedSection is SectionKey.Logs;
     public string PerplexityEndpointUrl => $"http://127.0.0.1:{PerplexityPort}";
     public bool IsPerplexityFocused => IsPerplexityEngineSelected;
 
+    public string NineRouterInstalledVersion => NineRouterEngine.InstalledVersion ?? "Not installed";
+    public string? NineRouterLatestVersion => NineRouterEngine.LatestVersion;
+    public bool NineRouterUpdateAvailable => NineRouterEngine.UpdateAvailable;
+    public string NineRouterStatusText => BuildEngineStatusText(NineRouterEngine);
+    public ServerState NineRouterServerState => ToServerState(NineRouterEngine.State);
+    public int NineRouterPort => _settings.Current.GetOrAddEngine(EngineCatalog.NineRouter.Id, EngineCatalog.NineRouter.DefaultPort).Port;
+    public string NineRouterEndpointUrl => $"http://127.0.0.1:{NineRouterPort}";
+    public string NineRouterDashboardUrl => $"http://127.0.0.1:{NineRouterPort}/dashboard";
+
     partial void OnSelectedSectionChanged(SectionKey value)
     {
         OnPropertyChanged(nameof(IsConfigSection));
@@ -886,6 +901,11 @@ SelectedSection is SectionKey.Logs;
             FocusedConfigEngineId = EngineCatalog.CliProxyApi.Id;
         else if (value == SectionKey.ConfigPerplexity)
             FocusedConfigEngineId = EngineCatalog.PerplexityWebUiScraper.Id;
+        else if (value == SectionKey.ConfigNineRouter)
+        {
+            FocusedConfigEngineId = EngineCatalog.NineRouter.Id;
+            _ = RefreshNineRouterNodeMissingAsync();
+        }
     }
 
     partial void OnProvidersEngineIdChanged(string value)
@@ -1081,6 +1101,7 @@ SelectedSection is SectionKey.Logs;
             EnsureInitialLogsLoad();
 
             _ = ObserveStartupTaskAsync(LoadEngineReleasesAsync());
+            _ = ObserveStartupTaskAsync(RefreshNineRouterNodeMissingAsync());
         }
         catch (Exception ex)
         {
@@ -1407,6 +1428,14 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(PerplexityServerState));
         OnPropertyChanged(nameof(PerplexityPort));
         OnPropertyChanged(nameof(PerplexityEndpointUrl));
+        OnPropertyChanged(nameof(NineRouterInstalledVersion));
+        OnPropertyChanged(nameof(NineRouterLatestVersion));
+        OnPropertyChanged(nameof(NineRouterUpdateAvailable));
+        OnPropertyChanged(nameof(NineRouterStatusText));
+        OnPropertyChanged(nameof(NineRouterServerState));
+        OnPropertyChanged(nameof(NineRouterPort));
+        OnPropertyChanged(nameof(NineRouterEndpointUrl));
+        OnPropertyChanged(nameof(NineRouterDashboardUrl));
         OnPropertyChanged(nameof(EndpointUrl));
         OnPropertyChanged(nameof(Port));
         OnPropertyChanged(nameof(EditablePort));
@@ -2461,6 +2490,54 @@ SelectedSection is SectionKey.Logs;
         }
     }
 
+    [RelayCommand]
+    public void OpenNineRouterEngineFolder()
+    {
+        try { _folderOpen.OpenFolder(TunnelAgent.Infrastructure.Engine.NineRouter.DownloadService.DefaultEngineDir); }
+        catch (Exception ex)
+        {
+            ConfigurationStatusIsError = true;
+            ConfigurationStatusMessage = $"Could not open engine folder: {ex.Message}";
+            ShowConfigurationStatus = true;
+        }
+    }
+
+    [RelayCommand]
+    private void OpenNineRouterDashboard()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo(NineRouterDashboardUrl) { UseShellExecute = true });
+        }
+        catch { }
+    }
+
+    private async Task RefreshNineRouterNodeMissingAsync()
+    {
+        bool missing;
+        try
+        {
+            missing = await Task.Run(() => new NodeRuntimeDetector().Detect() is null);
+        }
+        catch
+        {
+            missing = true;
+        }
+
+        void Apply() => IsNineRouterNodeMissing = missing;
+        try
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+                Apply();
+            else
+                Dispatcher.UIThread.Post(Apply);
+        }
+        catch
+        {
+            Apply();
+        }
+    }
+
     [RelayCommand] private void ResetPerplexityAccounts() => ShowResetPerplexityDialog = true;
     [RelayCommand] private void DismissResetPerplexityDialog() => ShowResetPerplexityDialog = false;
 
@@ -3046,8 +3123,9 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(LocalProxyScrollRequestId));
     }
     [RelayCommand] private void SelectConfigPerplexity() => SelectedSection = SectionKey.ConfigPerplexity;
+    [RelayCommand] private void SelectConfigNineRouter() => SelectedSection = SectionKey.ConfigNineRouter;
 
-    public bool IsConfigSection => SelectedSection is SectionKey.ConfigGeneral or SectionKey.ConfigCliProxy or SectionKey.ConfigPerplexity;
+    public bool IsConfigSection => SelectedSection is SectionKey.ConfigGeneral or SectionKey.ConfigCliProxy or SectionKey.ConfigPerplexity or SectionKey.ConfigNineRouter;
 
     partial void OnSelectedQuotaProviderChanged(ProviderViewModel? value)
     {
@@ -3103,6 +3181,7 @@ SelectedSection is SectionKey.Logs;
         // Invalidate cache so manual check always fetches fresh data
         TunnelAgent.Infrastructure.Engine.CliProxy.DownloadService.InvalidateCache();
         TunnelAgent.Infrastructure.Engine.Perplexity.DownloadService.InvalidateCache();
+        TunnelAgent.Infrastructure.Engine.NineRouter.DownloadService.InvalidateCache();
         try
         {
             await FocusedConfigEngine.CheckForUpdateAsync();
@@ -3122,6 +3201,7 @@ SelectedSection is SectionKey.Logs;
         // Invalidate cache so Reload always fetches fresh data from GitHub
         TunnelAgent.Infrastructure.Engine.CliProxy.DownloadService.InvalidateCache();
         TunnelAgent.Infrastructure.Engine.Perplexity.DownloadService.InvalidateCache();
+        TunnelAgent.Infrastructure.Engine.NineRouter.DownloadService.InvalidateCache();
         await LoadEngineReleasesAsync();
     }
 
@@ -3155,7 +3235,9 @@ SelectedSection is SectionKey.Logs;
         // Stay on correct config section for the engine being updated.
         SelectedSection = string.Equals(engineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase)
             ? SectionKey.ConfigPerplexity
-            : SectionKey.ConfigCliProxy;
+            : string.Equals(engineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase)
+                ? SectionKey.ConfigNineRouter
+                : SectionKey.ConfigCliProxy;
         ShowUpdateToast = false;
         var requestedVersion = string.IsNullOrWhiteSpace(version) ? engine.LatestVersion : version;
         if (!string.IsNullOrWhiteSpace(requestedVersion) && !VersionsEqual(requestedVersion, engine.LatestVersion))
@@ -3166,13 +3248,16 @@ SelectedSection is SectionKey.Logs;
         _engineUpdateToastShown[engineId] = false;
         ShowUpdateSuccess = true;
         var isPerplexity = string.Equals(engineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase);
+        var isNineRouter = string.Equals(engineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase);
         if (isPerplexity) ShowPerplexityUpdateSuccess = true;
+        else if (isNineRouter) ShowNineRouterUpdateSuccess = true;
         else ShowCliProxyUpdateSuccess = true;
         _ = Task.Delay(4000).ContinueWith(_ => Dispatcher.UIThread.Post(() =>
         {
             ShowUpdateSuccess = false;
             ShowCliProxyUpdateSuccess = false;
             ShowPerplexityUpdateSuccess = false;
+            ShowNineRouterUpdateSuccess = false;
         }));
     }
 

--- a/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml
@@ -26,6 +26,7 @@
                         <ctrl:SlidingTab Header="{l:Loc ConfigView_TabGeneral}"    Command="{Binding SelectConfigGeneralCommand}" />
                         <ctrl:SlidingTab Header="{l:Loc ConfigView_TabCLIProxyAPI}" Command="{Binding SelectConfigCliProxyCommand}" />
                         <ctrl:SlidingTab Header="{l:Loc ConfigView_TabPerplexity}" Command="{Binding SelectConfigPerplexityCommand}" />
+                        <ctrl:SlidingTab Header="{l:Loc ConfigView_TabNineRouter}" Command="{Binding SelectConfigNineRouterCommand}" />
                     </ctrl:SlidingTabBar.Tabs>
                 </ctrl:SlidingTabBar>
 
@@ -597,6 +598,181 @@
                                             Command="{Binding ApplyPortCommand}"
                                             IsEnabled="{Binding CanApplyPort}" />
                                     <Button Classes="app" Content="{l:Loc ConfigView_Perplexity_ListenPort_Reset}" Command="{Binding ResetPortCommand}" />
+                                </StackPanel>
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- ══ 9ROUTER ══════════════════════════════════════════ -->
+                <StackPanel IsVisible="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=ConfigNineRouter}">
+                    <StackPanel Margin="0,0,0,14">
+                        <TextBlock Classes="page-title" Text="{l:Loc ConfigView_NineRouter_Title}" />
+                        <TextBlock Classes="page-sub" Text="{l:Loc ConfigView_NineRouter_Subtitle}" />
+                    </StackPanel>
+
+                    <Border Classes="alert warning" IsVisible="{Binding IsNineRouterNodeMissing}" Margin="0,0,0,8">
+                        <TextBlock Classes="alert-body" Text="{l:Loc ConfigView_NineRouter_NodeMissing}" />
+                    </Border>
+
+                    <!-- Update success banner -->
+                    <Border IsVisible="{Binding ShowNineRouterUpdateSuccess}" Background="{DynamicResource AccentBrush}"
+                            CornerRadius="8" Padding="12,8" Margin="0,0,0,8">
+                        <TextBlock Text="{l:LocFormat Key=ConfigView_NineRouter_UpdateSuccess, Path=NineRouterInstalledVersion}"
+                                   Foreground="White" FontSize="12" FontWeight="Medium"/>
+                    </Border>
+
+                    <TextBlock Classes="section-label" Text="{l:Loc ConfigView_CLIProxy_EngineSection}"/>
+                    <Border Classes="card">
+                        <StackPanel>
+                            <!-- Version row -->
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_Engine_Label}"/>
+                                    <StackPanel Orientation="Horizontal" Spacing="4" Margin="0,2,0,0">
+                                        <TextBlock Classes="row-desc"
+                                                   Text="{l:LocFormat Key=ConfigView_NineRouter_Engine_Installed, Path=NineRouterInstalledVersion}" />
+                                        <TextBlock Classes="row-desc" Text="→" IsVisible="{Binding NineRouterUpdateAvailable}" />
+                                        <TextBlock Classes="row-desc" Foreground="{DynamicResource AccentBrush}"
+                                                   Text="{l:LocFormat Key=ConfigView_NineRouter_Engine_Available, Path=NineRouterLatestVersion}"
+                                                   IsVisible="{Binding NineRouterUpdateAvailable}" />
+                                    </StackPanel>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                    <Button Classes="app" Content="{l:Loc ConfigView_NineRouter_Engine_Check}"
+                                            Command="{Binding CheckForUpdateCommand}"
+                                            IsEnabled="{Binding !IsCheckingForUpdate}"
+                                            IsVisible="{Binding !UpdateAvailable}" />
+                                    <Button Classes="app primary" Content="{l:Loc ConfigView_NineRouter_Engine_UpdateNow}"
+                                            Command="{Binding UpdateEngineCommand}"
+                                            IsVisible="{Binding UpdateAvailable}" />
+                                </StackPanel>
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <!-- Version selector -->
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_CLIProxy_EngineVersion_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{Binding SelectedEngineVersionDescription}"/>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                    <ComboBox ItemsSource="{Binding EngineReleases}" SelectedItem="{Binding SelectedEngineRelease}"
+                                              Cursor="Hand" IsEnabled="{Binding CanSelectEngineRelease}"
+                                              Width="150" Height="26" MinHeight="0" Padding="8,0"
+                                              VerticalAlignment="Center" VerticalContentAlignment="Center" />
+                                    <Button Classes="app" Content="{l:Loc ConfigView_CLIProxy_EngineVersion_Reload}"
+                                            Command="{Binding RefreshEngineReleasesCommand}"
+                                            IsEnabled="{Binding CanSelectEngineRelease}" VerticalAlignment="Center" />
+                                    <Button Classes="app primary" Content="{l:Loc ConfigView_CLIProxy_EngineVersion_Install}"
+                                            Command="{Binding InstallSelectedEngineCommand}"
+                                            IsEnabled="{Binding CanInstallSelectedEngine}" VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Grid>
+                            <!-- Download progress -->
+                            <StackPanel Margin="14,0,14,11"
+                                        IsVisible="{Binding EngineState, Converter={StaticResource EngineStateToText}, ConverterParameter=IsDownloading}">
+                                <ProgressBar Value="{Binding DownloadProgress}" Minimum="0" Maximum="100"
+                                             Height="4" CornerRadius="2"
+                                             Foreground="{DynamicResource AccentBrush}"
+                                             Background="{DynamicResource RowDividerBrush}" />
+                                <TextBlock Classes="row-desc" Margin="0,4,0,0" Text="{Binding EngineStatusText}" />
+                            </StackPanel>
+                            <Border Classes="row-divider"/>
+                            <!-- Package integrity -->
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_CLIProxy_Integrity_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_CLIProxy_Integrity_Description}"/>
+                                    <TextBlock Classes="row-desc" ToolTip.Tip="{Binding InstalledEngineHashFull}">
+                                        <Run Text="{Binding InstalledEngineHashLabel}" /><Run Text=": " /><Run Text="{Binding InstalledEngineHashShort}" />
+                                    </TextBlock>
+                                    <TextBlock Classes="row-desc" ToolTip.Tip="{Binding LatestEngineHashFull}">
+                                        <Run Text="{l:Loc ConfigView_CLIProxy_Integrity_RemotePackageSha256}" /><Run Text=": " /><Run Text="{Binding LatestEngineHashShort}" />
+                                    </TextBlock>
+                                    <TextBlock Classes="row-desc" Foreground="{DynamicResource ErrBrush}"
+                                               Text="{Binding EngineIntegrityMessage}"
+                                               IsVisible="{Binding HasEngineIntegrityError}" />
+                                </StackPanel>
+                                <Border Grid.Column="1" Classes="chip" Background="{DynamicResource AccentSoftBrush}"
+                                        VerticalAlignment="Center" ToolTip.Tip="{Binding LatestEngineAssetName}">
+                                    <TextBlock Text="{Binding EngineIntegrityStatus}" Foreground="{DynamicResource AccentBrush}" />
+                                </Border>
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <!-- Auto-start -->
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_CLIProxy_AutoStart_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_CLIProxy_AutoStart_Description}"/>
+                                </StackPanel>
+                                <ToggleButton Grid.Column="1" Classes="enable-toggle"
+                                              IsChecked="{Binding EngineAutoStart, Mode=TwoWay}" />
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <!-- Auto-check -->
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_CLIProxy_AutoCheck_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_CLIProxy_AutoCheck_Description}"/>
+                                </StackPanel>
+                                <ToggleButton Grid.Column="1" Classes="enable-toggle"
+                                              IsChecked="{Binding AutoCheckForUpdates, Mode=TwoWay}" />
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <!-- Auto-update -->
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_CLIProxy_AutoUpdate_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_CLIProxy_AutoUpdate_Description}"/>
+                                </StackPanel>
+                                <ToggleButton Grid.Column="1" Classes="enable-toggle"
+                                              IsChecked="{Binding AutoUpdate, Mode=TwoWay}"
+                                              IsEnabled="{Binding IsAutoUpdateEnabled}" />
+                            </Grid>
+
+                        </StackPanel>
+                    </Border>
+
+                    <TextBlock Classes="section-label" Text="{l:Loc ConfigView_CLIProxy_SecuritySection}"/>
+                    <Border Classes="card">
+                        <StackPanel>
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_EngineFolder_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_EngineFolder_Description}"/>
+                                </StackPanel>
+                                <Button Grid.Column="1" Classes="app" Content="{l:Loc ConfigView_NineRouter_EngineFolder_Open}"
+                                        Command="{Binding OpenNineRouterEngineFolderCommand}" />
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_Dashboard_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_Dashboard_Description}"/>
+                                    <TextBlock Classes="row-desc" Text="{Binding NineRouterDashboardUrl}" />
+                                </StackPanel>
+                                <Button Grid.Column="1" Classes="app" Content="{l:Loc ConfigView_NineRouter_Dashboard_Open}"
+                                        Command="{Binding OpenNineRouterDashboardCommand}" />
+                            </Grid>
+                        </StackPanel>
+                    </Border>
+
+                    <TextBlock Classes="section-label" Text="{l:Loc ConfigView_CLIProxy_NetworkSection}"/>
+                    <Border Classes="card">
+                        <StackPanel>
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_ListenPort_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_ListenPort_Description}"/>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                                    <TextBox Classes="app" Text="{Binding EditablePort, Mode=TwoWay}"
+                                             Width="70" Height="24" MinHeight="0" Padding="8,0" MaxLength="5"
+                                             VerticalContentAlignment="Center" HorizontalContentAlignment="Center" />
+                                    <Button Classes="app primary" Content="{l:Loc ConfigView_ListenPort_Apply}"
+                                            Command="{Binding ApplyPortCommand}"
+                                            IsEnabled="{Binding CanApplyPort}" />
+                                    <Button Classes="app" Content="{l:Loc ConfigView_NineRouter_ListenPort_Reset}" Command="{Binding ResetPortCommand}" />
                                 </StackPanel>
                             </Grid>
                         </StackPanel>

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
@@ -184,7 +184,7 @@ public partial class MainWindow : Window
     }
 
     private static SectionKey NormalizeSectionKey(SectionKey section) =>
-        section is SectionKey.ConfigGeneral or SectionKey.ConfigCliProxy or SectionKey.ConfigPerplexity
+        section is SectionKey.ConfigGeneral or SectionKey.ConfigCliProxy or SectionKey.ConfigPerplexity or SectionKey.ConfigNineRouter
             ? SectionKey.Configuration
             : section;
 

--- a/src/TunnelAgent.Core/Models/Enums.cs
+++ b/src/TunnelAgent.Core/Models/Enums.cs
@@ -3,7 +3,7 @@ namespace TunnelAgent.ViewModels;
 
 public enum ServerState { Stopped, Starting, Running, Error }
 
-public enum SectionKey { Home, Providers, Quota, Fallback, Agents, Logs, Configuration, ConfigGeneral, ConfigCliProxy, ConfigPerplexity }
+public enum SectionKey { Home, Providers, Quota, Fallback, Agents, Logs, Configuration, ConfigGeneral, ConfigCliProxy, ConfigPerplexity, ConfigNineRouter }
 
 /// <summary>Strategy for selecting which API key to use when multiple accounts are configured for a provider.</summary>
 public enum RoutingStrategy { RoundRobin, FillFirst }

--- a/tests/TunnelAgent.Tests/EnumTests.cs
+++ b/tests/TunnelAgent.Tests/EnumTests.cs
@@ -28,6 +28,7 @@ public sealed class EnumTests
         Assert.Contains(SectionKey.ConfigGeneral, values);
         Assert.Contains(SectionKey.ConfigCliProxy, values);
         Assert.Contains(SectionKey.ConfigPerplexity, values);
+        Assert.Contains(SectionKey.ConfigNineRouter, values);
     }
 
     [Fact]

--- a/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
@@ -33,6 +33,25 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task SelectConfigNineRouter_SetsTabIndexAndFocusedEngine()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var registry = new EngineRegistryService(settings);
+        var vm = new MainWindowViewModel(settings, registry, null!, null!, null!, null!);
+
+        vm.SelectConfigNineRouterCommand.Execute(null);
+
+        Assert.Equal(SectionKey.ConfigNineRouter, vm.SelectedSection);
+        Assert.Equal(3, vm.ConfigTabIndex);
+        Assert.True(vm.IsConfigSection);
+        Assert.Equal(EngineCatalog.NineRouter.Id, vm.FocusedConfigEngineId);
+        Assert.Equal(EngineCatalog.NineRouter.DefaultPort, vm.NineRouterPort);
+        Assert.Equal($"http://127.0.0.1:{EngineCatalog.NineRouter.DefaultPort}/dashboard", vm.NineRouterDashboardUrl);
+    }
+
+    [Fact]
     public async Task EngineService_InitialServerState_IsStopped()
     {
         using var temp = new TestTempDirectory();


### PR DESCRIPTION
Expose install, port, auto-start, dashboard, and Node.js requirements in Settings.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>