### PR TITLE
feat: add 9Router local management API client

### DIFF
--- a/docs/plan/2026-08-14-9router-engine.md
+++ b/docs/plan/2026-08-14-9router-engine.md
@@ -374,3 +374,38 @@ New `NineRouter/ApiClient.cs`:
 - Tests: xUnit `[Fact]`, `Method_Scenario_Expected` (`.agents/skills/csharp-xunit/SKILL.md`). Templates: [`PerplexityEngineServiceTests.cs`](../../tests/TunnelAgent.Tests/PerplexityEngineServiceTests.cs), [`PerplexityDownloadServiceTests.cs`](../../tests/TunnelAgent.Tests/PerplexityDownloadServiceTests.cs), [`PerplexityProcessServiceTests.cs`](../../tests/TunnelAgent.Tests/PerplexityProcessServiceTests.cs), [`EngineRegistryAndPerplexityTests.cs`](../../tests/TunnelAgent.Tests/EngineRegistryAndPerplexityTests.cs).
 - One phase per chat, one worktree, one stacked PR layer.
 - If a phase still overflows context, split UI vs tests vs resx **as extra stacked layers**, not as a second stack.
+
+---
+
+## Phase 7 API contract
+
+Captured from [decolua/9router](https://github.com/decolua/9router) `master` (`src/app/api/providers/route.js`, `[id]/route.js`, `validate/route.js`, `[id]/test/route.js`, `auth/login/route.js`, `keys/route.js`, `src/lib/auth/dashboardSession.js`). JSON property names are camelCase.
+
+Base URL: `http://127.0.0.1:{port}/` (default port `20128`).
+
+### Auth
+
+- Anonymous localhost may still work on older builds. Recent builds 401 `/api/providers/*` (and other `/api/*` outside `/v1`) unless the `auth_token` cookie is set.
+- `POST /api/auth/login` body: `{ "password": "..." }`. Success `200` `{ "success": true }` plus `Set-Cookie: auth_token=<JWT>; HttpOnly; Path=/; SameSite=Lax`. Failure `401` `{ "error": "Invalid password..." }`.
+- `ApiClient` retries once: on 401, login with the ctor password, store the cookie, replay the original request. Empty password skips login.
+
+### Providers
+
+| Method | Path | Request | Success |
+| --- | --- | --- | --- |
+| GET | `/api/providers` | — | `200` `{ "connections": [ { id, provider, authType, name, priority, isActive, testStatus, lastError, providerSpecificData, ... } ] }` (secrets stripped) |
+| POST | `/api/providers` | `{ "provider", "authType": "apikey", "name", "apiKey" }` plus optional `priority`, `defaultModel`, `providerSpecificData` | `201` `{ "connection": { ... } }` |
+| GET | `/api/providers/{id}` | — | `200` `{ "connection": { ... } }` |
+| PUT | `/api/providers/{id}` | `{ "name"?, "isActive"?, "apiKey"?, "priority"?, "defaultModel"?, "testStatus"? }` | `200` `{ "connection": { ... } }` |
+| DELETE | `/api/providers/{id}` | — | `200` `{ "message": "Connection deleted successfully" }` |
+| POST | `/api/providers/validate` | `{ "provider", "apiKey" }` | `200` `{ "valid": true/false, "error": null\|string }` |
+| POST | `/api/providers/{id}/test` | — | `200` `{ "valid", "error", "refreshed" }` |
+
+Enabled/disabled is `isActive`, not `enabled`/`disabled`. 9Router sets `authType` server-side (`apikey` vs `cookie`); sending `authType` on create is still accepted by the JSON body and matches public advisories.
+
+### Client API keys (`/v1` callers, not upstream provider keys)
+
+| Method | Path | Request | Success |
+| --- | --- | --- | --- |
+| GET | `/api/keys` | — | `200` `{ "keys": [ { id, name, key, machineId, isActive, createdAt } ] }` |
+| POST | `/api/keys` | `{ "name": "..." }` | `201` `{ "id", "name", "key", "machineId" }` |

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TunnelAgent.Infrastructure.Engine.NineRouter;
+
+/// <summary>
+/// HTTP client for 9Router's local dashboard management API
+/// (<c>http://127.0.0.1:{port}/api/...</c>). Talks to <c>/api/providers</c> and
+/// <c>/api/keys</c> instead of writing SQLite.
+/// </summary>
+/// <remarks>
+/// Recent 9Router builds require an <c>auth_token</c> cookie on
+/// <c>/api/providers/*</c>. When a request returns 401 and a dashboard password
+/// was supplied, this client posts <c>/api/auth/login</c>, stores the cookie, and
+/// retries once. An empty password tries anonymous access first and does not
+/// attempt login. Request bodies that may contain API keys are never logged.
+/// </remarks>
+public sealed class ApiClient : IDisposable
+{
+    /// <summary>Cookie name issued by <c>POST /api/auth/login</c>.</summary>
+    public const string AuthCookieName = "auth_token";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    private readonly HttpClient _http;
+    private readonly string? _dashboardPassword;
+    private readonly object _authLock = new();
+    private string? _authCookie;
+    private bool _disposed;
+
+    /// <summary>
+    /// Creates a client bound to <c>http://127.0.0.1:{port}</c>.
+    /// </summary>
+    /// <param name="port">Loopback port of the running 9Router process.</param>
+    /// <param name="dashboardPassword">
+    /// Optional dashboard password. Null or empty means try anonymous access and
+    /// skip login on 401.
+    /// </param>
+    public ApiClient(int port, string? dashboardPassword = null)
+        : this(port, new HttpClientHandler { UseCookies = false }, dashboardPassword, disposeHandler: true)
+    {
+    }
+
+    /// <summary>
+    /// Creates a client that sends requests through <paramref name="handler"/>
+    /// (used by unit tests to inject a fake <see cref="HttpMessageHandler"/>).
+    /// </summary>
+    /// <param name="port">Loopback port used to build the base address.</param>
+    /// <param name="handler">Transport used by the inner <see cref="HttpClient"/>.</param>
+    /// <param name="dashboardPassword">
+    /// Optional dashboard password. Null or empty means try anonymous access and
+    /// skip login on 401.
+    /// </param>
+    public ApiClient(int port, HttpMessageHandler handler, string? dashboardPassword = null)
+        : this(port, handler, dashboardPassword, disposeHandler: false)
+    {
+    }
+
+    private ApiClient(int port, HttpMessageHandler handler, string? dashboardPassword, bool disposeHandler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        if (port is < IPEndPoint.MinPort or > IPEndPoint.MaxPort || port == 0)
+            throw new ArgumentOutOfRangeException(nameof(port), port, "Port must be between 1 and 65535.");
+
+        Port = port;
+        _dashboardPassword = string.IsNullOrWhiteSpace(dashboardPassword) ? null : dashboardPassword;
+        _http = new HttpClient(handler, disposeHandler)
+        {
+            BaseAddress = new Uri($"http://127.0.0.1:{port}/"),
+            Timeout = TimeSpan.FromSeconds(30)
+        };
+        if (_http.DefaultRequestHeaders.UserAgent.Count == 0)
+            _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("TunnelAgent", TunnelAgent.AppVersion.Current));
+    }
+
+    /// <summary>Gets the loopback port this client was constructed with.</summary>
+    public int Port { get; }
+
+    /// <summary>Gets whether a dashboard password was supplied (not whether login has succeeded).</summary>
+    public bool HasDashboardPassword => _dashboardPassword is not null;
+
+    /// <summary>Lists provider connections via <c>GET /api/providers</c>.</summary>
+    /// <param name="ct">Token used to cancel the request.</param>
+    /// <returns>The <c>connections</c> array from the JSON envelope.</returns>
+    public async Task<IReadOnlyList<NineRouterProvider>> ListProvidersAsync(CancellationToken ct = default)
+    {
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Get, "api/providers", body: null, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<ProviderListResponse>(response, ct).ConfigureAwait(false);
+        return payload.Connections ?? [];
+    }
+
+    /// <summary>Creates an API-key connection via <c>POST /api/providers</c>.</summary>
+    /// <param name="request">Provider id, display name, and API key.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    /// <returns>The created connection with secrets stripped by 9Router.</returns>
+    public async Task<NineRouterProvider> CreateProviderAsync(
+        NineRouterCreateProviderRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Post, "api/providers", request, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<ProviderEnvelope>(response, ct).ConfigureAwait(false);
+        return payload.Connection
+            ?? throw new NineRouterApiException(response.StatusCode, "Create provider response did not include a connection.");
+    }
+
+    /// <summary>Updates a connection via <c>PUT /api/providers/{id}</c>.</summary>
+    /// <param name="id">Connection id from <see cref="NineRouterProvider.Id"/>.</param>
+    /// <param name="request">Fields to change. Null properties are omitted.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    /// <returns>The updated connection with secrets stripped by 9Router.</returns>
+    public async Task<NineRouterProvider> UpdateProviderAsync(
+        string id,
+        NineRouterUpdateProviderRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentNullException.ThrowIfNull(request);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Put, ProviderPath(id), request, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<ProviderEnvelope>(response, ct).ConfigureAwait(false);
+        return payload.Connection
+            ?? throw new NineRouterApiException(response.StatusCode, "Update provider response did not include a connection.");
+    }
+
+    /// <summary>Deletes a connection via <c>DELETE /api/providers/{id}</c>.</summary>
+    /// <param name="id">Connection id from <see cref="NineRouterProvider.Id"/>.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task DeleteProviderAsync(string id, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Delete, ProviderPath(id), body: null, ct)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Dry-runs credentials via <c>POST /api/providers/validate</c> without saving them.</summary>
+    /// <param name="request">Provider id and API key to probe.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterValidationResult> ValidateProviderAsync(
+        NineRouterValidateProviderRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Post, "api/providers/validate", request, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<ValidationResponse>(response, ct).ConfigureAwait(false);
+        return new NineRouterValidationResult(payload.Valid, payload.Error);
+    }
+
+    /// <summary>Tests a stored connection via <c>POST /api/providers/{id}/test</c>.</summary>
+    /// <param name="id">Connection id from <see cref="NineRouterProvider.Id"/>.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterTestResult> TestProviderAsync(string id, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Post, $"{ProviderPath(id)}/test", body: null, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<TestResponse>(response, ct).ConfigureAwait(false);
+        return new NineRouterTestResult(payload.Valid, payload.Error, payload.Refreshed);
+    }
+
+    /// <summary>Lists client API keys for <c>/v1</c> via <c>GET /api/keys</c>.</summary>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<IReadOnlyList<NineRouterApiKey>> ListKeysAsync(CancellationToken ct = default)
+    {
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Get, "api/keys", body: null, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<KeyListResponse>(response, ct).ConfigureAwait(false);
+        return payload.Keys ?? [];
+    }
+
+    /// <summary>Creates a client API key via <c>POST /api/keys</c> with <c>{"name":"..."}</c>.</summary>
+    /// <param name="name">Dashboard display name for the new key.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    /// <returns>The issued key, including the secret once.</returns>
+    public async Task<NineRouterCreatedApiKey> CreateKeyAsync(string name, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        using var response = await SendWithAuthRetryAsync(
+                HttpMethod.Post,
+                "api/keys",
+                new CreateKeyRequest(name),
+                ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterCreatedApiKey>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        _http.Dispose();
+    }
+
+    private async Task<HttpResponseMessage> SendWithAuthRetryAsync(
+        HttpMethod method,
+        string relativePath,
+        object? body,
+        CancellationToken ct)
+    {
+        var response = await SendOnceAsync(method, relativePath, body, ct).ConfigureAwait(false);
+        if (response.StatusCode != HttpStatusCode.Unauthorized || _dashboardPassword is null)
+            return response;
+
+        response.Dispose();
+        await LoginAsync(ct).ConfigureAwait(false);
+        return await SendOnceAsync(method, relativePath, body, ct).ConfigureAwait(false);
+    }
+
+    private async Task<HttpResponseMessage> SendOnceAsync(
+        HttpMethod method,
+        string relativePath,
+        object? body,
+        CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(method, relativePath);
+        if (body is not null)
+            request.Content = CreateJsonContent(body);
+        AttachCookie(request);
+        var response = await _http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+            .ConfigureAwait(false);
+        CaptureCookie(response);
+        return response;
+    }
+
+    private async Task LoginAsync(CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, "api/auth/login")
+        {
+            Content = CreateJsonContent(new LoginRequest(_dashboardPassword!))
+        };
+        using var response = await _http.SendAsync(request, ct).ConfigureAwait(false);
+        CaptureCookie(response);
+
+        if (response.IsSuccessStatusCode)
+        {
+            var payload = await TryDeserializeAsync<LoginResponse>(response, ct).ConfigureAwait(false);
+            if (payload is { Success: false })
+            {
+                throw new NineRouterAuthException(
+                    payload.Error ?? "Dashboard login was rejected.",
+                    response.StatusCode);
+            }
+
+            return;
+        }
+
+        var error = await TryReadErrorAsync(response, ct).ConfigureAwait(false);
+        throw new NineRouterAuthException(
+            error ?? $"Dashboard login failed with HTTP {(int)response.StatusCode}.",
+            response.StatusCode);
+    }
+
+    private void AttachCookie(HttpRequestMessage request)
+    {
+        string? cookie;
+        lock (_authLock)
+            cookie = _authCookie;
+        if (string.IsNullOrEmpty(cookie))
+            return;
+        request.Headers.TryAddWithoutValidation("Cookie", $"{AuthCookieName}={cookie}");
+    }
+
+    private void CaptureCookie(HttpResponseMessage response)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var values))
+            return;
+
+        foreach (var header in values)
+        {
+            var token = TryParseAuthCookie(header);
+            if (token is null)
+                continue;
+            lock (_authLock)
+                _authCookie = token;
+            return;
+        }
+    }
+
+    internal static string? TryParseAuthCookie(string? setCookieHeader)
+    {
+        if (string.IsNullOrWhiteSpace(setCookieHeader))
+            return null;
+
+        foreach (var part in setCookieHeader.Split(';'))
+        {
+            var trimmed = part.Trim();
+            const string prefix = AuthCookieName + "=";
+            if (!trimmed.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                continue;
+            var value = trimmed[prefix.Length..].Trim();
+            return value.Length == 0 ? null : value;
+        }
+
+        return null;
+    }
+
+    private async Task<T> ReadJsonAsync<T>(HttpResponseMessage response, CancellationToken ct)
+    {
+        await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
+        var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+        try
+        {
+            var parsed = JsonSerializer.Deserialize<T>(json, JsonOptions);
+            if (parsed is null)
+                throw new NineRouterApiException(response.StatusCode, "Management API returned empty JSON.");
+            return parsed;
+        }
+        catch (JsonException ex)
+        {
+            throw new NineRouterApiException(
+                response.StatusCode,
+                $"Management API returned invalid JSON: {ex.Message}");
+        }
+    }
+
+    private static async Task EnsureSuccessAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+
+        var error = await TryReadErrorAsync(response, ct).ConfigureAwait(false);
+        var message = error ?? $"9Router management API returned HTTP {(int)response.StatusCode}.";
+        if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+            throw new NineRouterAuthException(message, response.StatusCode);
+        throw new NineRouterApiException(response.StatusCode, message);
+    }
+
+    private static async Task<string?> TryReadErrorAsync(HttpResponseMessage response, CancellationToken ct)
+    {
+        var payload = await TryDeserializeAsync<ErrorResponse>(response, ct).ConfigureAwait(false);
+        return string.IsNullOrWhiteSpace(payload?.Error) ? null : payload.Error;
+    }
+
+    private static async Task<T?> TryDeserializeAsync<T>(HttpResponseMessage response, CancellationToken ct)
+        where T : class
+    {
+        try
+        {
+            var json = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(json))
+                return null;
+            return JsonSerializer.Deserialize<T>(json, JsonOptions);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static ByteArrayContent CreateJsonContent(object value)
+    {
+        var bytes = JsonSerializer.SerializeToUtf8Bytes(value, JsonOptions);
+        var content = new ByteArrayContent(bytes);
+        content.Headers.ContentType = new MediaTypeHeaderValue("application/json")
+        {
+            CharSet = Encoding.UTF8.WebName
+        };
+        return content;
+    }
+
+    private static string ProviderPath(string id) =>
+        "api/providers/" + Uri.EscapeDataString(id);
+
+    private sealed record ProviderListResponse(List<NineRouterProvider>? Connections, string? Error);
+
+    private sealed record ProviderEnvelope(NineRouterProvider? Connection, string? Error);
+
+    private sealed record ValidationResponse(bool Valid, string? Error);
+
+    private sealed record TestResponse(bool Valid, string? Error, bool Refreshed);
+
+    private sealed record KeyListResponse(List<NineRouterApiKey>? Keys, string? Error);
+
+    private sealed record CreateKeyRequest(string Name);
+
+    private sealed record LoginRequest(string Password);
+
+    private sealed record LoginResponse(bool Success, string? Error);
+
+    private sealed record ErrorResponse(string? Error);
+}

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Net;
+using System.Text.Json;
+
+namespace TunnelAgent.Infrastructure.Engine.NineRouter;
+
+/// <summary>
+/// Thrown when the 9Router local management API returns a non-success status.
+/// Response bodies are surfaced as <see cref="Exception.Message"/>; request bodies
+/// (which may contain API keys) are never included.
+/// </summary>
+public class NineRouterApiException : Exception
+{
+    /// <summary>Creates an exception for a failed management-API response.</summary>
+    /// <param name="statusCode">HTTP status returned by 9Router.</param>
+    /// <param name="message">Safe error text from the status line or JSON <c>error</c> field.</param>
+    public NineRouterApiException(HttpStatusCode statusCode, string message)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+
+    /// <summary>Gets the HTTP status code returned by 9Router.</summary>
+    public HttpStatusCode StatusCode { get; }
+}
+
+/// <summary>
+/// Thrown when dashboard authentication is required and either no password was
+/// configured or <c>POST /api/auth/login</c> failed.
+/// </summary>
+public sealed class NineRouterAuthException : NineRouterApiException
+{
+    /// <summary>Creates an authentication failure for a 401/403 dashboard response.</summary>
+    /// <param name="message">Safe error text that does not include the password.</param>
+    /// <param name="statusCode">HTTP status from the API or login attempt. Defaults to 401.</param>
+    public NineRouterAuthException(string message, HttpStatusCode statusCode = HttpStatusCode.Unauthorized)
+        : base(statusCode, message)
+    {
+    }
+}
+
+/// <summary>
+/// A provider connection returned by <c>GET/POST/PUT /api/providers</c>.
+/// Sensitive credential fields are omitted by 9Router in list/detail responses.
+/// </summary>
+public sealed record NineRouterProvider
+{
+    /// <summary>Gets the connection id.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Gets the 9Router provider id (for example <c>openai</c>).</summary>
+    public string? Provider { get; init; }
+
+    /// <summary>Gets the auth mode, typically <c>apikey</c>, <c>oauth</c>, or <c>cookie</c>.</summary>
+    public string? AuthType { get; init; }
+
+    /// <summary>Gets the dashboard display name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Gets the per-provider priority used for fallback.</summary>
+    public int? Priority { get; init; }
+
+    /// <summary>Gets the optional global priority.</summary>
+    public int? GlobalPriority { get; init; }
+
+    /// <summary>Gets whether the connection is enabled. 9Router stores this as <c>isActive</c>.</summary>
+    public bool? IsActive { get; init; }
+
+    /// <summary>Gets the optional default model for this connection.</summary>
+    public string? DefaultModel { get; init; }
+
+    /// <summary>Gets the last test status string (for example <c>unknown</c>).</summary>
+    public string? TestStatus { get; init; }
+
+    /// <summary>Gets the last connection error, if any.</summary>
+    public string? LastError { get; init; }
+
+    /// <summary>Gets when <see cref="LastError"/> was recorded, if present.</summary>
+    public string? LastErrorAt { get; init; }
+
+    /// <summary>Gets provider-specific extra fields such as <c>baseUrl</c> or proxy settings.</summary>
+    public JsonElement? ProviderSpecificData { get; init; }
+}
+
+/// <summary>
+/// Body for <c>POST /api/providers</c> when adding an API-key (or cookie) connection.
+/// </summary>
+public sealed record NineRouterCreateProviderRequest
+{
+    /// <summary>Gets the 9Router provider id (for example <c>openai</c>).</summary>
+    public required string Provider { get; init; }
+
+    /// <summary>Gets the dashboard display name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the upstream API key or cookie value. Never logged by <see cref="ApiClient"/>.</summary>
+    public required string ApiKey { get; init; }
+
+    /// <summary>Gets the auth mode sent to 9Router. Defaults to <c>apikey</c>.</summary>
+    public string AuthType { get; init; } = "apikey";
+
+    /// <summary>Gets the optional per-provider priority.</summary>
+    public int? Priority { get; init; }
+
+    /// <summary>Gets the optional default model.</summary>
+    public string? DefaultModel { get; init; }
+}
+
+/// <summary>Body for <c>PUT /api/providers/{id}</c>. Null properties are omitted from JSON.</summary>
+public sealed record NineRouterUpdateProviderRequest
+{
+    /// <summary>Gets the replacement display name, if changing it.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Gets whether the connection should be enabled (<c>isActive</c>).</summary>
+    public bool? IsActive { get; init; }
+
+    /// <summary>Gets a replacement API key for <c>apikey</c> connections. Never logged by <see cref="ApiClient"/>.</summary>
+    public string? ApiKey { get; init; }
+
+    /// <summary>Gets the replacement per-provider priority, if changing it.</summary>
+    public int? Priority { get; init; }
+
+    /// <summary>Gets the replacement default model, if changing it.</summary>
+    public string? DefaultModel { get; init; }
+
+    /// <summary>Gets the replacement test-status string, if changing it.</summary>
+    public string? TestStatus { get; init; }
+}
+
+/// <summary>Body for <c>POST /api/providers/validate</c> (dry-run credential check).</summary>
+public sealed record NineRouterValidateProviderRequest
+{
+    /// <summary>Gets the 9Router provider id to probe.</summary>
+    public required string Provider { get; init; }
+
+    /// <summary>Gets the API key to validate. Never logged by <see cref="ApiClient"/>.</summary>
+    public string? ApiKey { get; init; }
+}
+
+/// <summary>Result of <c>POST /api/providers/validate</c>.</summary>
+/// <param name="Valid">Whether 9Router accepted the credentials.</param>
+/// <param name="Error">Failure text from 9Router, if any.</param>
+public sealed record NineRouterValidationResult(bool Valid, string? Error);
+
+/// <summary>Result of <c>POST /api/providers/{id}/test</c>.</summary>
+/// <param name="Valid">Whether the stored connection responded successfully.</param>
+/// <param name="Error">Failure text from 9Router, if any.</param>
+/// <param name="Refreshed">Whether 9Router refreshed OAuth credentials during the test.</param>
+public sealed record NineRouterTestResult(bool Valid, string? Error, bool Refreshed);
+
+/// <summary>
+/// A client API key from <c>GET /api/keys</c>. These keys authenticate callers of
+/// <c>/v1</c>; they are not upstream provider keys.
+/// </summary>
+public sealed record NineRouterApiKey
+{
+    /// <summary>Gets the key id.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Gets the dashboard display name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Gets the secret key value when 9Router includes it. Never logged by <see cref="ApiClient"/>.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>Gets the machine id the key is bound to.</summary>
+    public string? MachineId { get; init; }
+
+    /// <summary>Gets whether the key is enabled.</summary>
+    public bool? IsActive { get; init; }
+
+    /// <summary>Gets the ISO-8601 creation timestamp, if present.</summary>
+    public string? CreatedAt { get; init; }
+}
+
+/// <summary>Response from <c>POST /api/keys</c> (201). Includes the newly issued secret once.</summary>
+public sealed record NineRouterCreatedApiKey
+{
+    /// <summary>Gets the new key id.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Gets the dashboard display name.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Gets the newly issued secret. Never logged by <see cref="ApiClient"/>.</summary>
+    public string? Key { get; init; }
+
+    /// <summary>Gets the machine id the key is bound to.</summary>
+    public string? MachineId { get; init; }
+}

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -1,0 +1,362 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+
+namespace TunnelAgent.Tests;
+
+public sealed class NineRouterApiClientTests
+{
+    private const int Port = 20128;
+
+    [Fact]
+    public async Task ListProvidersAsync_200WithConnections_ParsesList()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "connections": [
+                {
+                  "id": "conn-1",
+                  "provider": "openai",
+                  "authType": "apikey",
+                  "name": "OpenAI",
+                  "priority": 1,
+                  "isActive": true,
+                  "testStatus": "unknown"
+                },
+                {
+                  "id": "conn-2",
+                  "provider": "kiro",
+                  "authType": "oauth",
+                  "name": "Kiro",
+                  "isActive": false
+                }
+              ]
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var providers = await client.ListProvidersAsync();
+
+        Assert.Equal(2, providers.Count);
+        Assert.Equal("conn-1", providers[0].Id);
+        Assert.Equal("openai", providers[0].Provider);
+        Assert.Equal("apikey", providers[0].AuthType);
+        Assert.Equal("OpenAI", providers[0].Name);
+        Assert.Equal(1, providers[0].Priority);
+        Assert.True(providers[0].IsActive);
+        Assert.Equal("unknown", providers[0].TestStatus);
+        Assert.Equal("conn-2", providers[1].Id);
+        Assert.False(providers[1].IsActive);
+        Assert.Equal("GET", handler.Requests[0].Method);
+        Assert.Equal("/api/providers", handler.Requests[0].Path);
+        Assert.Null(handler.Requests[0].Cookie);
+        Assert.Null(handler.Requests[0].Body);
+    }
+
+    [Fact]
+    public async Task CreateProviderAsync_PostsCamelCaseBody_Returns201Connection()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.Created, """
+            {
+              "connection": {
+                "id": "conn-new",
+                "provider": "openai",
+                "authType": "apikey",
+                "name": "My OpenAI",
+                "isActive": true,
+                "testStatus": "unknown"
+              }
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var created = await client.CreateProviderAsync(new NineRouterCreateProviderRequest
+        {
+            Provider = "openai",
+            AuthType = "apikey",
+            Name = "My OpenAI",
+            ApiKey = "sk-test-key"
+        });
+
+        Assert.Equal("conn-new", created.Id);
+        Assert.Equal("openai", created.Provider);
+        Assert.Equal("My OpenAI", created.Name);
+        Assert.True(created.IsActive);
+        Assert.Equal("POST", handler.Requests[0].Method);
+        Assert.Equal("/api/providers", handler.Requests[0].Path);
+
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("openai", body.RootElement.GetProperty("provider").GetString());
+        Assert.Equal("apikey", body.RootElement.GetProperty("authType").GetString());
+        Assert.Equal("My OpenAI", body.RootElement.GetProperty("name").GetString());
+        Assert.Equal("sk-test-key", body.RootElement.GetProperty("apiKey").GetString());
+        Assert.False(body.RootElement.TryGetProperty("priority", out _));
+    }
+
+    [Fact]
+    public async Task CreateProviderAsync_200Envelope_StillParsesConnection()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "connection": { "id": "conn-200", "provider": "openai", "name": "Ok" } }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var created = await client.CreateProviderAsync(new NineRouterCreateProviderRequest
+        {
+            Provider = "openai",
+            Name = "Ok",
+            ApiKey = "sk-ok"
+        });
+
+        Assert.Equal("conn-200", created.Id);
+        Assert.Equal("Ok", created.Name);
+    }
+
+    [Fact]
+    public async Task UpdateProviderAsync_PutsIsActive_ReturnsUpdatedConnection()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "connection": { "id": "conn-1", "provider": "openai", "name": "OpenAI", "isActive": false } }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var updated = await client.UpdateProviderAsync("conn-1", new NineRouterUpdateProviderRequest { IsActive = false });
+
+        Assert.Equal("conn-1", updated.Id);
+        Assert.False(updated.IsActive);
+        Assert.Equal("PUT", handler.Requests[0].Method);
+        Assert.Equal("/api/providers/conn-1", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.False(body.RootElement.GetProperty("isActive").GetBoolean());
+        Assert.False(body.RootElement.TryGetProperty("apiKey", out _));
+    }
+
+    [Fact]
+    public async Task DeleteProviderAsync_204Or200_Completes()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "message": "Connection deleted successfully" }""");
+        using var client = new ApiClient(Port, handler);
+
+        await client.DeleteProviderAsync("conn-1");
+
+        Assert.Equal("DELETE", handler.Requests[0].Method);
+        Assert.Equal("/api/providers/conn-1", handler.Requests[0].Path);
+        Assert.Null(handler.Requests[0].Body);
+    }
+
+    [Fact]
+    public async Task ValidateProviderAsync_ValidTrue_ReturnsResult()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "valid": true, "error": null }""");
+        using var client = new ApiClient(Port, handler);
+
+        var result = await client.ValidateProviderAsync(new NineRouterValidateProviderRequest
+        {
+            Provider = "openai",
+            ApiKey = "sk-test-key"
+        });
+
+        Assert.True(result.Valid);
+        Assert.Null(result.Error);
+        Assert.Equal("POST", handler.Requests[0].Method);
+        Assert.Equal("/api/providers/validate", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("openai", body.RootElement.GetProperty("provider").GetString());
+        Assert.Equal("sk-test-key", body.RootElement.GetProperty("apiKey").GetString());
+    }
+
+    [Fact]
+    public async Task TestProviderAsync_ValidWithRefresh_ReturnsResult()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "valid": true, "error": null, "refreshed": true }""");
+        using var client = new ApiClient(Port, handler);
+
+        var result = await client.TestProviderAsync("conn-1");
+
+        Assert.True(result.Valid);
+        Assert.True(result.Refreshed);
+        Assert.Equal("POST", handler.Requests[0].Method);
+        Assert.Equal("/api/providers/conn-1/test", handler.Requests[0].Path);
+    }
+
+    [Fact]
+    public async Task ListKeysAsync_200WithKeys_ParsesList()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "keys": [
+                { "id": "k1", "name": "default", "key": "sk-9r-secret", "machineId": "m1", "isActive": true }
+              ]
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var keys = await client.ListKeysAsync();
+
+        Assert.Single(keys);
+        Assert.Equal("k1", keys[0].Id);
+        Assert.Equal("default", keys[0].Name);
+        Assert.Equal("sk-9r-secret", keys[0].Key);
+        Assert.True(keys[0].IsActive);
+        Assert.Equal("/api/keys", handler.Requests[0].Path);
+    }
+
+    [Fact]
+    public async Task CreateKeyAsync_PostsName_Returns201Key()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.Created, """
+            { "id": "k2", "name": "tunnel-agent", "key": "sk-9r-new", "machineId": "m1" }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var created = await client.CreateKeyAsync("tunnel-agent");
+
+        Assert.Equal("k2", created.Id);
+        Assert.Equal("tunnel-agent", created.Name);
+        Assert.Equal("sk-9r-new", created.Key);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("tunnel-agent", body.RootElement.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task ListProvidersAsync_401ThenLoginCookieThenRetry_Succeeds()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.Unauthorized, """{ "error": "Unauthorized" }""");
+        handler.EnqueueJson(
+            HttpStatusCode.OK,
+            """{ "success": true, "mustChangePassword": false }""",
+            setCookie: "auth_token=jwt-from-login; HttpOnly; Path=/; SameSite=Lax");
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "connections": [ { "id": "conn-1", "provider": "openai", "name": "OpenAI", "isActive": true } ] }
+            """);
+        using var client = new ApiClient(Port, handler, dashboardPassword: "secret-password");
+
+        var providers = await client.ListProvidersAsync();
+
+        Assert.Single(providers);
+        Assert.Equal("conn-1", providers[0].Id);
+        Assert.Equal(3, handler.Requests.Count);
+
+        Assert.Equal("GET", handler.Requests[0].Method);
+        Assert.Equal("/api/providers", handler.Requests[0].Path);
+        Assert.Null(handler.Requests[0].Cookie);
+
+        Assert.Equal("POST", handler.Requests[1].Method);
+        Assert.Equal("/api/auth/login", handler.Requests[1].Path);
+        using (var loginBody = JsonDocument.Parse(handler.Requests[1].Body!))
+            Assert.Equal("secret-password", loginBody.RootElement.GetProperty("password").GetString());
+
+        Assert.Equal("GET", handler.Requests[2].Method);
+        Assert.Equal("/api/providers", handler.Requests[2].Path);
+        Assert.Equal("auth_token=jwt-from-login", handler.Requests[2].Cookie);
+    }
+
+    [Fact]
+    public async Task ListProvidersAsync_401ThenLoginFailure_ThrowsNineRouterAuthException()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.Unauthorized, """{ "error": "Unauthorized" }""");
+        handler.EnqueueJson(HttpStatusCode.Unauthorized, """{ "error": "Invalid password. 2 attempt(s) left before lockout." }""");
+        using var client = new ApiClient(Port, handler, dashboardPassword: "wrong-password");
+
+        var ex = await Assert.ThrowsAsync<NineRouterAuthException>(() => client.ListProvidersAsync());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+        Assert.Contains("Invalid password", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("wrong-password", ex.Message, StringComparison.Ordinal);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("/api/auth/login", handler.Requests[1].Path);
+    }
+
+    [Fact]
+    public async Task ListProvidersAsync_401WithoutPassword_ThrowsWithoutLoginAttempt()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.Unauthorized, """{ "error": "Unauthorized" }""");
+        using var client = new ApiClient(Port, handler, dashboardPassword: null);
+
+        var ex = await Assert.ThrowsAsync<NineRouterAuthException>(() => client.ListProvidersAsync());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/providers", handler.Requests[0].Path);
+        Assert.False(client.HasDashboardPassword);
+    }
+
+    [Fact]
+    public void Constructor_InvalidPort_Throws()
+    {
+        using var handler = new FakeApiHandler();
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ApiClient(0, handler));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ApiClient(65536, handler));
+    }
+
+    [Fact]
+    public void TryParseAuthCookie_SetCookieHeader_ExtractsToken()
+    {
+        var token = ApiClient.TryParseAuthCookie("auth_token=abc.def; HttpOnly; Path=/; SameSite=Lax");
+
+        Assert.Equal("abc.def", token);
+    }
+
+    private sealed class FakeApiHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _responses = new();
+
+        public List<CapturedRequest> Requests { get; } = [];
+
+        public void EnqueueJson(HttpStatusCode status, string json, string? setCookie = null)
+        {
+            _responses.Enqueue(() =>
+            {
+                var response = new HttpResponseMessage(status)
+                {
+                    Content = new StringContent(json, Encoding.UTF8, "application/json")
+                };
+                if (setCookie is not null)
+                    response.Headers.TryAddWithoutValidation("Set-Cookie", setCookie);
+                return response;
+            });
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string? body = null;
+            if (request.Content is not null)
+                body = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            var uri = request.RequestUri ?? throw new InvalidOperationException("Request URI was null.");
+            var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
+            if (!path.StartsWith('/'))
+                path = "/" + path.TrimStart('/');
+
+            request.Headers.TryGetValues("Cookie", out var cookies);
+            Requests.Add(new CapturedRequest(
+                request.Method.Method,
+                path,
+                string.IsNullOrEmpty(body) ? null : body,
+                cookies?.FirstOrDefault()));
+
+            if (_responses.Count == 0)
+                throw new InvalidOperationException($"Unexpected {request.Method} {path}");
+
+            return _responses.Dequeue()();
+        }
+    }
+
+    private sealed record CapturedRequest(string Method, string Path, string? Body, string? Cookie);
+}


### PR DESCRIPTION
Talk to /api/providers and dashboard login over HTTP instead of writing SQLite.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>