### PR TITLE
feat: manage 9Router connections from the Providers tab

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -514,6 +514,9 @@
   <data name="ProvidersView_TabPerplexity" xml:space="preserve">
     <value>Perplexity</value>
   </data>
+  <data name="ProvidersView_TabNineRouter" xml:space="preserve">
+    <value>9Router</value>
+  </data>
   <data name="ProvidersView_Title" xml:space="preserve">
     <value>Services</value>
   </data>
@@ -550,6 +553,73 @@
   </data>
   <data name="ProvidersView_PerplexityAccount_RemoveTooltip" xml:space="preserve">
     <value>Remove account</value>
+  </data>
+
+  <data name="ProvidersView_NineRouterSection_Title" xml:space="preserve">
+    <value>9Router connections</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_Description" xml:space="preserve">
+    <value>Provider connections stored by the running 9Router engine.</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_AuthFiles" xml:space="preserve">
+    <value>9Router connections are stored by the running 9Router engine.</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_AddTooltip" xml:space="preserve">
+    <value>Add API key</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_NoConnections" xml:space="preserve">
+    <value>No connections yet</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_EmptyState" xml:space="preserve">
+    <value>Start 9Router, then add an API key or connect a free provider.</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectKiro" xml:space="preserve">
+    <value>Connect Kiro</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
+    <value>Connect OpenCode Free</value>
+  </data>
+  <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
+    <value>Delete connection</value>
+  </data>
+  <data name="ProvidersView_NineRouter_EngineNotRunning" xml:space="preserve">
+    <value>Start 9Router before managing connections.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_CreateFailed" xml:space="preserve">
+    <value>Could not add the 9Router connection: {0}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_LoadFailed" xml:space="preserve">
+    <value>Could not load 9Router connections: {0}</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_Title" xml:space="preserve">
+    <value>Add API key</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_ProviderId" xml:space="preserve">
+    <value>Provider id</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_ProviderIdPlaceholder" xml:space="preserve">
+    <value>openai</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_NamePlaceholder" xml:space="preserve">
+    <value>Optional display name</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_ApiKey" xml:space="preserve">
+    <value>API key</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_ApiKeyPlaceholder" xml:space="preserve">
+    <value>sk-…</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_ShowHideTooltip" xml:space="preserve">
+    <value>Show or hide API key</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_Cancel" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+  <data name="Dialog_AddNineRouterKey_Save" xml:space="preserve">
+    <value>Add</value>
   </data>
   <data name="ProvidersView_PerplexityAccount_DefaultBadge" xml:space="preserve">
     <value>default</value>

--- a/src/TunnelAgent.Avalonia/Services/ModelFetchService.cs
+++ b/src/TunnelAgent.Avalonia/Services/ModelFetchService.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+using TunnelAgent.Core.Engine;
 using TunnelAgent.ViewModels;
 
 namespace TunnelAgent.Services;
@@ -53,7 +54,7 @@ public sealed class ModelFetchService
             try
             {
                 using var request = new HttpRequestMessage(HttpMethod.Get, url);
-                var apiKey = TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get("TUNNEL_AGENT_CLIPROXY_API_KEY") ?? "";
+                var apiKey = ApiKeyForEngine(engineId);
                 if (!string.IsNullOrWhiteSpace(apiKey))
                     request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {apiKey}");
                 using var resp = await Http.SendAsync(request, ct);
@@ -120,6 +121,23 @@ public sealed class ModelFetchService
     }
 
     // ── helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Bearer token for <c>/v1/models</c>, chosen by engine so 9Router and
+    /// Perplexity do not inherit the CLIProxy key.
+    /// </summary>
+    /// <param name="engineId">
+    /// Catalog id (<c>cliproxyapi</c>, <c>perplexity-webui-scraper</c>,
+    /// <c>9router</c>). Null or unknown ids use the CLIProxy key.
+    /// </param>
+    internal static string ApiKeyForEngine(string? engineId)
+    {
+        if (string.Equals(engineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase))
+            return "";
+        if (string.Equals(engineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase))
+            return TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get(NineRouterClientKeyService.EnvVarName) ?? "";
+        return TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get("TUNNEL_AGENT_CLIPROXY_API_KEY") ?? "";
+    }
 
     private static int CountOwnedBy(JsonArray data, string ownedBy)
     {

--- a/src/TunnelAgent.Avalonia/Services/NineRouterClientKeyService.cs
+++ b/src/TunnelAgent.Avalonia/Services/NineRouterClientKeyService.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+using TunnelAgent.Infrastructure.Services;
+
+namespace TunnelAgent.Services;
+
+/// <summary>
+/// Ensures a 9Router client API key exists for <c>/v1</c> callers and stores it
+/// in the user environment as <see cref="EnvVarName"/>.
+/// </summary>
+public sealed class NineRouterClientKeyService
+{
+    /// <summary>User-environment variable agents use as the 9Router <c>/v1</c> Bearer token.</summary>
+    public const string EnvVarName = "TUNNEL_AGENT_9ROUTER_API_KEY";
+
+    /// <summary>Display name used when creating a new dashboard key.</summary>
+    public const string DefaultKeyName = "Tunnel Agent";
+
+    /// <summary>
+    /// If <see cref="EnvVarName"/> is empty, lists existing <c>/api/keys</c> entries
+    /// and creates one named <see cref="DefaultKeyName"/> when none exist, then
+    /// writes the secret to the user environment off the UI thread.
+    /// </summary>
+    /// <param name="client">Management API client bound to the running 9Router port.</param>
+    /// <param name="ct">Token used to cancel list/create.</param>
+    public async Task EnsureUserApiKeyAsync(ApiClient client, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        if (!string.IsNullOrWhiteSpace(UserEnvironmentService.Get(EnvVarName)))
+            return;
+
+        var keys = await client.ListKeysAsync(ct).ConfigureAwait(false);
+        var secret = keys.FirstOrDefault(k => !string.IsNullOrWhiteSpace(k.Key))?.Key;
+        if (string.IsNullOrWhiteSpace(secret))
+        {
+            var created = await client.CreateKeyAsync(DefaultKeyName, ct).ConfigureAwait(false);
+            secret = created.Key;
+        }
+
+        if (string.IsNullOrWhiteSpace(secret))
+            return;
+
+        var value = secret;
+        await Task.Run(() => UserEnvironmentService.Set(EnvVarName, value), ct).ConfigureAwait(false);
+    }
+}

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -75,8 +75,10 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
     private bool _quotaScannedOnce;
     private bool _quotaScanInProgress;
 
+    private readonly NineRouterClientKeyService _nineRouterClientKey = new();
     private CancellationTokenSource? _cliProxyModelFetchCts;
     private CancellationTokenSource? _perplexityModelFetchCts;
+    private CancellationTokenSource? _nineRouterModelFetchCts;
     private string? _pendingCliProxyModelOwner;
     private int _pendingCliProxyModelCount;
     private bool _engineReleaseSelectionReady;
@@ -216,6 +218,12 @@ SelectedSection is SectionKey.Logs;
     [ObservableProperty] private PerplexityAccountViewModel? _editPerplexityLabelTarget;
     [ObservableProperty] private string _editPerplexityLabelDraft = "";
     [ObservableProperty] private bool _showResetPerplexityDialog;
+    [ObservableProperty] private bool _showNineRouterAddKeyDialog;
+    [ObservableProperty] private string _nineRouterAddProviderIdDraft = "";
+    [ObservableProperty] private string _nineRouterAddNameDraft = "";
+    [ObservableProperty] private string _nineRouterAddApiKeyDraft = "";
+    [ObservableProperty] private bool _showNineRouterAddApiKey;
+    [ObservableProperty] private bool _isNineRouterBusy;
 
     [ObservableProperty] private bool _showOAuthStatus;
     [ObservableProperty] private bool _oAuthStatusIsError;
@@ -344,11 +352,13 @@ SelectedSection is SectionKey.Logs;
     public ObservableCollection<ProviderViewModel> StandaloneQuotaProviders { get; } = new();
     public ObservableCollection<QuotaProviderViewModel> QuotaAccounts { get; } = new();
     public ObservableCollection<PerplexityAccountViewModel> PerplexityAccounts { get; } = new();
+    public ObservableCollection<NineRouterConnectionViewModel> NineRouterConnections { get; } = new();
     public ObservableCollection<AgentViewModel> Agents { get; } = new();
     public ObservableCollection<EngineReleaseViewModel> EngineReleases { get; } = new();
     public ObservableCollection<AvailableModelGroupViewModel> AvailableModelGroups { get; }
     public ObservableCollection<AvailableModelGroupViewModel> CliProxyModelGroups { get; }
     public ObservableCollection<AvailableModelGroupViewModel> PerplexityModelGroups { get; }
+    public ObservableCollection<AvailableModelGroupViewModel> NineRouterModelGroups { get; }
     public ObservableCollection<EngineOptionViewModel> EngineOptions { get; } = new();
     public ObservableCollection<CliProxyApiKeyViewModel> CliProxyApiKeys { get; } = new();
     public ObservableCollection<SelectableModelViewModel> SelectableModels { get; } = new();
@@ -386,6 +396,7 @@ SelectedSection is SectionKey.Logs;
 
         CliProxyModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
         PerplexityModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
+        NineRouterModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
         AvailableModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
 
         void OnEngineModelsChanged(object? s, System.Collections.Specialized.NotifyCollectionChangedEventArgs _)
@@ -393,6 +404,7 @@ SelectedSection is SectionKey.Logs;
             AvailableModelGroups.Clear();
             foreach (var g in CliProxyModelGroups) AvailableModelGroups.Add(g);
             foreach (var g in PerplexityModelGroups) AvailableModelGroups.Add(g);
+            foreach (var g in NineRouterModelGroups) AvailableModelGroups.Add(g);
             OnPropertyChanged(nameof(FocusedModelGroups));
             OnPropertyChanged(nameof(TotalAvailableModelCount));
             OnPropertyChanged(nameof(HasCliProxySelectableModels));
@@ -401,6 +413,7 @@ SelectedSection is SectionKey.Logs;
         }
         CliProxyModelGroups.CollectionChanged += OnEngineModelsChanged;
         PerplexityModelGroups.CollectionChanged += OnEngineModelsChanged;
+        NineRouterModelGroups.CollectionChanged += OnEngineModelsChanged;
         AvailableModelGroups.CollectionChanged += (_, _) =>
         {
             OnPropertyChanged(nameof(TotalAvailableModelCount));
@@ -455,9 +468,11 @@ SelectedSection is SectionKey.Logs;
     // Providers submenu highlight — independent from Config section
     public bool IsCliProxyEngineSelected => string.Equals(ProvidersEngineId, EngineCatalog.CliProxyApi.Id, StringComparison.OrdinalIgnoreCase);
     public bool IsPerplexityEngineSelected => string.Equals(ProvidersEngineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase);
+    public bool IsNineRouterEngineSelected => string.Equals(ProvidersEngineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase);
 
     // Tab indices for SlidingTabBar
-    public int ProvidersTabIndex => IsPerplexityEngineSelected ? 1 : 0;
+    public int ProvidersTabIndex =>
+        IsPerplexityEngineSelected ? 1 : IsNineRouterEngineSelected ? 2 : 0;
     public int ConfigTabIndex => SelectedSection switch
     {
         SectionKey.ConfigCliProxy => 1,
@@ -577,14 +592,20 @@ SelectedSection is SectionKey.Logs;
         ? _localization.GetString("AgentConfigOverlay_BulkDescription")
         : AgentConfigTarget?.Description ?? "";
     public IEnumerable<AvailableModelGroupViewModel> FocusedModelGroups =>
-        IsPerplexityEngineSelected ? PerplexityModelGroups : CliProxyModelGroups;
+        IsNineRouterEngineSelected ? NineRouterModelGroups
+        : IsPerplexityEngineSelected ? PerplexityModelGroups
+        : CliProxyModelGroups;
     public int TotalAvailableModelCount => FocusedModelGroups.Sum(g => g.ModelCount);
     public int PerplexityAccountCount => PerplexityAccounts.Count;
     public bool HasPerplexityAccounts => PerplexityAccounts.Count > 0;
     public string PerplexityEmptyStateText => "Perplexity needs at least one saved WebUI session token account.";
-    public string AuthFilesDescription => IsPerplexityEngineSelected
-        ? "Perplexity session accounts are stored in app settings."
-        : "OAuth tokens and custom provider keys are stored in the app auth folder.";
+    public bool HasNineRouterConnections => NineRouterConnections.Count > 0;
+    public bool IsNineRouterEngineRunning => NineRouterEngine.State == EngineState.Running;
+    public string AuthFilesDescription => IsNineRouterEngineSelected
+        ? _localization.GetString("ProvidersView_NineRouterSection_AuthFiles")
+        : IsPerplexityEngineSelected
+            ? "Perplexity session accounts are stored in app settings."
+            : "OAuth tokens and custom provider keys are stored in the app auth folder.";
 
     private IManagedEngine FocusedConfigEngine => _engineRegistry.Get(FocusedConfigEngineId);
     private IManagedEngine CliProxyEngine => _engineRegistry.Get(EngineCatalog.CliProxyApi.Id);
@@ -912,9 +933,13 @@ SelectedSection is SectionKey.Logs;
     {
         OnPropertyChanged(nameof(IsCliProxyEngineSelected));
         OnPropertyChanged(nameof(IsPerplexityEngineSelected));
+        OnPropertyChanged(nameof(IsNineRouterEngineSelected));
         OnPropertyChanged(nameof(ProvidersTabIndex));
         OnPropertyChanged(nameof(FocusedModelGroups));
         OnPropertyChanged(nameof(TotalAvailableModelCount));
+        OnPropertyChanged(nameof(AuthFilesDescription));
+        if (IsNineRouterEngineSelected && NineRouterEngine.State == EngineState.Running)
+            _ = RefreshNineRouterConnectionsAsync();
     }
 
     partial void OnFocusedConfigEngineIdChanged(string value)
@@ -1062,8 +1087,8 @@ SelectedSection is SectionKey.Logs;
             foreach (var engine in _engineRegistry.Engines)
             {
                 if (engine.State != EngineState.Running) continue;
-                var isCliProxy = string.Equals(engine.Definition.Id, EngineCatalog.CliProxyApi.Id, StringComparison.OrdinalIgnoreCase);
-                if (isCliProxy)
+                var engineId = engine.Definition.Id;
+                if (string.Equals(engineId, EngineCatalog.CliProxyApi.Id, StringComparison.OrdinalIgnoreCase))
                 {
                     _cliProxyModelFetchCts = new CancellationTokenSource();
                     _ = ObserveStartupTaskAsync(Task.Run(() =>
@@ -1083,11 +1108,18 @@ SelectedSection is SectionKey.Logs;
                         UpdateLogsPollingState();
                     }
                 }
-                else
+                else if (string.Equals(engineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase))
                 {
                     _perplexityModelFetchCts = new CancellationTokenSource();
                     _ = ObserveStartupTaskAsync(Task.Run(() =>
                         _modelFetch.FetchAndApplyAsync(PerplexityModelGroups, engine.Port, engine.Definition.Id, _perplexityModelFetchCts.Token)));
+                }
+                else if (string.Equals(engineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    _nineRouterModelFetchCts = new CancellationTokenSource();
+                    var token = _nineRouterModelFetchCts.Token;
+                    _ = ObserveStartupTaskAsync(Task.Run(() => FetchNineRouterModelsAsync(engine, token)));
+                    _ = ObserveStartupTaskAsync(RefreshNineRouterConnectionsAsync());
                 }
             }
 
@@ -1267,26 +1299,26 @@ SelectedSection is SectionKey.Logs;
         {
             if (sender is IManagedEngine engine)
             {
-                var isCliProxy = string.Equals(engine.Definition.Id, EngineCatalog.CliProxyApi.Id, StringComparison.OrdinalIgnoreCase);
-                var modelGroups = isCliProxy ? CliProxyModelGroups : PerplexityModelGroups;
-                ref var cts = ref isCliProxy ? ref _cliProxyModelFetchCts : ref _perplexityModelFetchCts;
+                var engineId = engine.Definition.Id;
+                var isCliProxy = string.Equals(engineId, EngineCatalog.CliProxyApi.Id, StringComparison.OrdinalIgnoreCase);
+                var isPerplexity = string.Equals(engineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase);
+                var isNineRouter = string.Equals(engineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase);
+                var modelGroups = isCliProxy ? CliProxyModelGroups
+                    : isPerplexity ? PerplexityModelGroups
+                    : isNineRouter ? NineRouterModelGroups
+                    : null;
 
                 if (engine.State == EngineState.Running)
                 {
                     // A successful (re)start clears the last error so a future failure re-toasts.
                     _lastEngineErrorShown.Remove(engine.Definition.Id);
-                    if (cts is null || cts.IsCancellationRequested)
-                    {
-                        cts = new CancellationTokenSource();
-                        if (isCliProxy && _pendingCliProxyModelOwner is { } owner && _pendingCliProxyModelCount > 0)
-                        {
-                            _ = FetchPendingCliProxyModelsAsync(engine, cts.Token, owner, _pendingCliProxyModelCount);
-                        }
-                        else
-                        {
-                            _ = _modelFetch.FetchAndApplyAsync(modelGroups, engine.Port, engine.Definition.Id, cts.Token);
-                        }
-                    }
+                    if (isCliProxy)
+                        StartCliProxyModelFetch(engine);
+                    else if (isPerplexity)
+                        StartPerplexityModelFetch(engine);
+                    else if (isNineRouter)
+                        StartNineRouterModelFetch(engine);
+
                     if (isCliProxy)
                     {
                         ConfigureLogsService(engine.Port);
@@ -1303,12 +1335,29 @@ SelectedSection is SectionKey.Logs;
                             UpdateLogsPollingState();
                         }
                     }
+                    if (isNineRouter)
+                        _ = RefreshNineRouterConnectionsAsync();
                 }
                 else if (engine.State == EngineState.Stopped || engine.State == EngineState.Error)
                 {
-                    cts?.Cancel();
-                    cts = null;
-                    modelGroups.Clear();
+                    if (isCliProxy)
+                    {
+                        _cliProxyModelFetchCts?.Cancel();
+                        _cliProxyModelFetchCts = null;
+                    }
+                    else if (isPerplexity)
+                    {
+                        _perplexityModelFetchCts?.Cancel();
+                        _perplexityModelFetchCts = null;
+                    }
+                    else if (isNineRouter)
+                    {
+                        _nineRouterModelFetchCts?.Cancel();
+                        _nineRouterModelFetchCts = null;
+                        NineRouterConnections.Clear();
+                        OnPropertyChanged(nameof(HasNineRouterConnections));
+                    }
+                    modelGroups?.Clear();
                     if (isCliProxy)
                     {
                         _logs.SetManagementApiAvailable(false);
@@ -1368,6 +1417,54 @@ SelectedSection is SectionKey.Logs;
 
             RefreshEngineSectionProperties();
         });
+    }
+
+    private void StartCliProxyModelFetch(IManagedEngine engine)
+    {
+        if (_cliProxyModelFetchCts is not null && !_cliProxyModelFetchCts.IsCancellationRequested)
+            return;
+        _cliProxyModelFetchCts = new CancellationTokenSource();
+        if (_pendingCliProxyModelOwner is { } owner && _pendingCliProxyModelCount > 0)
+            _ = FetchPendingCliProxyModelsAsync(engine, _cliProxyModelFetchCts.Token, owner, _pendingCliProxyModelCount);
+        else
+            _ = _modelFetch.FetchAndApplyAsync(CliProxyModelGroups, engine.Port, engine.Definition.Id, _cliProxyModelFetchCts.Token);
+    }
+
+    private void StartPerplexityModelFetch(IManagedEngine engine)
+    {
+        if (_perplexityModelFetchCts is not null && !_perplexityModelFetchCts.IsCancellationRequested)
+            return;
+        _perplexityModelFetchCts = new CancellationTokenSource();
+        _ = _modelFetch.FetchAndApplyAsync(PerplexityModelGroups, engine.Port, engine.Definition.Id, _perplexityModelFetchCts.Token);
+    }
+
+    private void StartNineRouterModelFetch(IManagedEngine engine)
+    {
+        if (_nineRouterModelFetchCts is not null && !_nineRouterModelFetchCts.IsCancellationRequested)
+            return;
+        _nineRouterModelFetchCts = new CancellationTokenSource();
+        var token = _nineRouterModelFetchCts.Token;
+        _ = FetchNineRouterModelsAsync(engine, token);
+    }
+
+    private async Task FetchNineRouterModelsAsync(IManagedEngine engine, CancellationToken token)
+    {
+        try
+        {
+            using var client = new ApiClient(engine.Port);
+            await _nineRouterClientKey.EnsureUserApiKeyAsync(client, token);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            TraceStartupWarning("Failed to sync 9Router API key", ex);
+        }
+
+        if (token.IsCancellationRequested) return;
+        await _modelFetch.FetchAndApplyAsync(NineRouterModelGroups, engine.Port, engine.Definition.Id, token);
     }
 
     private string? BuildEngineErrorMessage(IManagedEngine engine)
@@ -1436,6 +1533,7 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(NineRouterPort));
         OnPropertyChanged(nameof(NineRouterEndpointUrl));
         OnPropertyChanged(nameof(NineRouterDashboardUrl));
+        OnPropertyChanged(nameof(IsNineRouterEngineRunning));
         OnPropertyChanged(nameof(EndpointUrl));
         OnPropertyChanged(nameof(Port));
         OnPropertyChanged(nameof(EditablePort));
@@ -2299,6 +2397,7 @@ SelectedSection is SectionKey.Logs;
     [RelayCommand] private void ToggleApiKeyDraftVisibility() => ShowApiKeyDraft = !ShowApiKeyDraft;
     [RelayCommand] private void ToggleAddAccountApiKeyVisibility() => ShowAddAccountApiKey = !ShowAddAccountApiKey;
     [RelayCommand] private void TogglePerplexitySessionTokenVisibility() => ShowPerplexitySessionToken = !ShowPerplexitySessionToken;
+    [RelayCommand] private void ToggleNineRouterAddApiKeyVisibility() => ShowNineRouterAddApiKey = !ShowNineRouterAddApiKey;
     [RelayCommand] private void ToggleAmpUpstreamApiKeyVisibility() => ShowAmpUpstreamApiKey = !ShowAmpUpstreamApiKey;
 
     [RelayCommand]
@@ -2363,6 +2462,230 @@ SelectedSection is SectionKey.Logs;
     {
         ProvidersEngineId = EngineCatalog.PerplexityWebUiScraper.Id;
         FocusedConfigEngineId = EngineCatalog.PerplexityWebUiScraper.Id;
+    }
+
+    [RelayCommand]
+    private void FocusNineRouter()
+    {
+        ProvidersEngineId = EngineCatalog.NineRouter.Id;
+        FocusedConfigEngineId = EngineCatalog.NineRouter.Id;
+    }
+
+    [RelayCommand]
+    private void ShowAddNineRouterApiKey()
+    {
+        NineRouterAddProviderIdDraft = "";
+        NineRouterAddNameDraft = "";
+        NineRouterAddApiKeyDraft = "";
+        ShowNineRouterAddApiKey = false;
+        ShowNineRouterAddKeyDialog = true;
+    }
+
+    [RelayCommand]
+    private void DismissNineRouterAddKeyDialog()
+    {
+        ShowNineRouterAddKeyDialog = false;
+        ShowNineRouterAddApiKey = false;
+        NineRouterAddProviderIdDraft = "";
+        NineRouterAddNameDraft = "";
+        NineRouterAddApiKeyDraft = "";
+    }
+
+    public async Task ConfirmAddNineRouterApiKeyAsync(string providerId, string? name, string apiKey)
+    {
+        DismissNineRouterAddKeyDialog();
+        var displayName = string.IsNullOrWhiteSpace(name) ? providerId.Trim() : name.Trim();
+        await CreateNineRouterProviderAsync(providerId.Trim(), displayName, apiKey);
+    }
+
+    [RelayCommand]
+    private Task ConnectNineRouterKiroAsync() =>
+        CreateNineRouterProviderAsync("kiro", "Kiro AI", NoAuthApiKeyPlaceholder);
+
+    [RelayCommand]
+    private async Task ConnectNineRouterOpenCodeFreeAsync()
+    {
+        if (!IsNineRouterEngineRunning)
+        {
+            ShowNineRouterStatus(_localization.GetString("ProvidersView_NineRouter_EngineNotRunning"), isError: true);
+            return;
+        }
+
+        if (IsNineRouterBusy) return;
+        IsNineRouterBusy = true;
+        try
+        {
+            Exception? last = null;
+            foreach (var providerId in OpenCodeFreeProviderIds)
+            {
+                try
+                {
+                    await PostNineRouterProviderAsync(providerId, "OpenCode Free", NoAuthApiKeyPlaceholder);
+                    await RefreshNineRouterConnectionsAsync();
+                    RestartNineRouterModelFetch();
+                    return;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    last = ex;
+                }
+            }
+
+            ShowNineRouterStatus(
+                _localization.GetString("ProvidersView_NineRouter_CreateFailed", last?.Message ?? "opencode"),
+                isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task ToggleNineRouterConnectionAsync(NineRouterConnectionViewModel? connection)
+    {
+        if (connection is null || !IsNineRouterEngineRunning || IsNineRouterBusy) return;
+        IsNineRouterBusy = true;
+        try
+        {
+            using var client = new ApiClient(NineRouterEngine.Port);
+            await client.UpdateProviderAsync(
+                connection.Id,
+                new NineRouterUpdateProviderRequest { IsActive = !connection.IsActive });
+            await RefreshNineRouterConnectionsAsync();
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task DeleteNineRouterConnectionAsync(NineRouterConnectionViewModel? connection)
+    {
+        if (connection is null || !IsNineRouterEngineRunning || IsNineRouterBusy) return;
+        IsNineRouterBusy = true;
+        try
+        {
+            using var client = new ApiClient(NineRouterEngine.Port);
+            await client.DeleteProviderAsync(connection.Id);
+            await RefreshNineRouterConnectionsAsync();
+            RestartNineRouterModelFetch();
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    private const string NoAuthApiKeyPlaceholder = "none";
+    private static readonly string[] OpenCodeFreeProviderIds = ["opencode", "opencode-zen", "opencode-free"];
+
+    private async Task CreateNineRouterProviderAsync(string providerId, string name, string apiKey)
+    {
+        if (!IsNineRouterEngineRunning)
+        {
+            ShowNineRouterStatus(_localization.GetString("ProvidersView_NineRouter_EngineNotRunning"), isError: true);
+            return;
+        }
+
+        if (IsNineRouterBusy) return;
+        IsNineRouterBusy = true;
+        try
+        {
+            await PostNineRouterProviderAsync(providerId, name, apiKey);
+            await RefreshNineRouterConnectionsAsync();
+            RestartNineRouterModelFetch();
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(
+                _localization.GetString("ProvidersView_NineRouter_CreateFailed", ex.Message),
+                isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    private async Task PostNineRouterProviderAsync(string providerId, string name, string apiKey)
+    {
+        using var client = new ApiClient(NineRouterEngine.Port);
+        await client.CreateProviderAsync(new NineRouterCreateProviderRequest
+        {
+            Provider = providerId,
+            Name = name,
+            ApiKey = apiKey,
+            AuthType = "apikey"
+        });
+    }
+
+    private async Task RefreshNineRouterConnectionsAsync()
+    {
+        if (NineRouterEngine.State != EngineState.Running)
+        {
+            await Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                NineRouterConnections.Clear();
+                OnPropertyChanged(nameof(HasNineRouterConnections));
+            });
+            return;
+        }
+
+        try
+        {
+            using var client = new ApiClient(NineRouterEngine.Port);
+            var connections = await client.ListProvidersAsync();
+            await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections));
+        }
+        catch (Exception ex)
+        {
+            await Dispatcher.UIThread.InvokeAsync(() =>
+                ShowNineRouterStatus(
+                    _localization.GetString("ProvidersView_NineRouter_LoadFailed", ex.Message),
+                    isError: true));
+        }
+    }
+
+    private void ApplyNineRouterConnections(IReadOnlyList<NineRouterProvider> connections)
+    {
+        NineRouterConnections.Clear();
+        foreach (var connection in connections)
+        {
+            NineRouterConnections.Add(new NineRouterConnectionViewModel(
+                connection.Id ?? "",
+                connection.Provider ?? "",
+                connection.Name ?? "",
+                connection.IsActive ?? true,
+                connection.LastError));
+        }
+        OnPropertyChanged(nameof(HasNineRouterConnections));
+    }
+
+    private void RestartNineRouterModelFetch()
+    {
+        if (NineRouterEngine.State != EngineState.Running) return;
+        _nineRouterModelFetchCts?.Cancel();
+        _nineRouterModelFetchCts = null;
+        StartNineRouterModelFetch(NineRouterEngine);
+    }
+
+    private void ShowNineRouterStatus(string message, bool isError)
+    {
+        ShowOAuthStatus = false;
+        OAuthStatusUrl = "";
+        OAuthStatusIsError = isError;
+        OAuthStatusMessage = message;
+        ShowOAuthStatus = true;
     }
 
 
@@ -3477,6 +3800,10 @@ SelectedSection is SectionKey.Logs;
         _perplexityModelFetchCts?.Cancel();
         _perplexityModelFetchCts?.Dispose();
         _perplexityModelFetchCts = null;
+
+        _nineRouterModelFetchCts?.Cancel();
+        _nineRouterModelFetchCts?.Dispose();
+        _nineRouterModelFetchCts = null;
 
         foreach (var engine in _engineRegistry.Engines)
             engine.StateChanged -= OnAnyEngineStateChanged;

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterConnectionViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterConnectionViewModel.cs
@@ -1,0 +1,40 @@
+namespace TunnelAgent.ViewModels;
+
+/// <summary>
+/// One 9Router provider connection shown on the Providers tab.
+/// </summary>
+public sealed class NineRouterConnectionViewModel
+{
+    /// <summary>Creates a row from a management-API connection.</summary>
+    /// <param name="id">Connection id used for update/delete.</param>
+    /// <param name="providerId">9Router provider id (for example <c>openai</c>).</param>
+    /// <param name="name">Dashboard display name.</param>
+    /// <param name="isActive">Whether the connection is enabled (<c>isActive</c>).</param>
+    /// <param name="lastError">Last connection error, if any.</param>
+    public NineRouterConnectionViewModel(string id, string providerId, string name, bool isActive, string? lastError)
+    {
+        Id = id;
+        ProviderId = providerId;
+        Name = string.IsNullOrWhiteSpace(name) ? providerId : name;
+        IsActive = isActive;
+        LastError = lastError;
+    }
+
+    /// <summary>Gets the connection id.</summary>
+    public string Id { get; }
+
+    /// <summary>Gets the 9Router provider id.</summary>
+    public string ProviderId { get; }
+
+    /// <summary>Gets the display name.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets whether the connection is enabled.</summary>
+    public bool IsActive { get; }
+
+    /// <summary>Gets the last error text, if 9Router reported one.</summary>
+    public string? LastError { get; }
+
+    /// <summary>Gets whether <see cref="LastError"/> should be shown.</summary>
+    public bool HasLastError => !string.IsNullOrWhiteSpace(LastError);
+}

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -874,6 +874,57 @@
             </Border>
         </Border>
 
+        <!-- Add 9Router API-key connection dialog -->
+        <Border x:Name="NineRouterAddKeyOverlay" IsVisible="{Binding ShowNineRouterAddKeyDialog}" Background="#88000000"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ZIndex="50"
+                KeyDown="OnNineRouterAddKeyDialogKeyDown" Focusable="True"
+                PointerPressed="OnNineRouterAddKeyOverlayPressed">
+            <Border Classes="card" Width="440" MinHeight="150" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="24"
+                    PointerPressed="OnDialogCardPressed">
+                <StackPanel Spacing="14">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0" Classes="row-label" FontSize="15" Text="{l:Loc Dialog_AddNineRouterKey_Title}" VerticalAlignment="Center" />
+                        <Button Grid.Column="1" Classes="icon" Command="{Binding DismissNineRouterAddKeyDialogCommand}" VerticalAlignment="Center">
+                            <lucide:PackIconLucide Kind="X" Width="14" Height="14" />
+                        </Button>
+                    </Grid>
+                    <StackPanel Spacing="4">
+                        <TextBlock Classes="row-desc" Text="{l:Loc Dialog_AddNineRouterKey_ProviderId}" />
+                        <TextBox x:Name="NineRouterProviderIdBox" Classes="app"
+                                 Watermark="{l:Loc Dialog_AddNineRouterKey_ProviderIdPlaceholder}"
+                                 Text="{Binding NineRouterAddProviderIdDraft, Mode=TwoWay}"
+                                 KeyDown="OnNineRouterAddKeyInputKeyDown" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Classes="row-desc" Text="{l:Loc Dialog_AddNineRouterKey_Name}" />
+                        <TextBox x:Name="NineRouterNameBox" Classes="app"
+                                 Watermark="{l:Loc Dialog_AddNineRouterKey_NamePlaceholder}"
+                                 Text="{Binding NineRouterAddNameDraft, Mode=TwoWay}"
+                                 KeyDown="OnNineRouterAddKeyInputKeyDown" />
+                    </StackPanel>
+                    <StackPanel Spacing="4">
+                        <TextBlock Classes="row-desc" Text="{l:Loc Dialog_AddNineRouterKey_ApiKey}" />
+                        <Grid ColumnDefinitions="*,Auto">
+                            <TextBox Grid.Column="0" x:Name="NineRouterApiKeyBox" Classes="app"
+                                     PasswordChar="{Binding ShowNineRouterAddApiKey, Converter={StaticResource SecretPasswordChar}}"
+                                     Watermark="{l:Loc Dialog_AddNineRouterKey_ApiKeyPlaceholder}"
+                                     Text="{Binding NineRouterAddApiKeyDraft, Mode=TwoWay}"
+                                     KeyDown="OnNineRouterAddKeyInputKeyDown" />
+                            <Button Grid.Column="1" Classes="icon-btn" Margin="8,0,0,0"
+                                    ToolTip.Tip="{l:Loc Dialog_AddNineRouterKey_ShowHideTooltip}"
+                                    Command="{Binding ToggleNineRouterAddApiKeyVisibilityCommand}">
+                                <lucide:PackIconLucide Kind="{Binding ShowNineRouterAddApiKey, Converter={StaticResource EyeIcon}}" Width="14" Height="14" />
+                            </Button>
+                        </Grid>
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,6,0,0">
+                        <Button Classes="app" Content="{l:Loc Dialog_AddNineRouterKey_Cancel}" Command="{Binding DismissNineRouterAddKeyDialogCommand}" />
+                        <Button Classes="app primary" Content="{l:Loc Dialog_AddNineRouterKey_Save}" Click="OnConfirmNineRouterAddKey" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Border>
+
         <!-- Edit Perplexity account label dialog -->
         <Border IsVisible="{Binding ShowEditPerplexityLabelDialog}" Background="#88000000"
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ZIndex="50"

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
@@ -309,6 +309,50 @@ public partial class MainWindow : Window
     private async void OnConfirmPerplexityAccount(object? sender, RoutedEventArgs e) =>
         await ConfirmPerplexityAccountFromInputsAsync();
 
+    private async void OnConfirmNineRouterAddKey(object? sender, RoutedEventArgs e) =>
+        await ConfirmNineRouterAddKeyFromInputsAsync();
+
+    private async Task ConfirmNineRouterAddKeyFromInputsAsync()
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        var providerId = NineRouterProviderIdBox.Text?.Trim() ?? "";
+        var name = NineRouterNameBox.Text?.Trim();
+        var apiKey = NineRouterApiKeyBox.Text?.Trim() ?? "";
+        if (string.IsNullOrEmpty(providerId) || string.IsNullOrEmpty(apiKey)) return;
+
+        NineRouterProviderIdBox.Text = "";
+        NineRouterNameBox.Text = "";
+        NineRouterApiKeyBox.Text = "";
+        await vm.ConfirmAddNineRouterApiKeyAsync(providerId, string.IsNullOrEmpty(name) ? null : name, apiKey);
+    }
+
+    private async void OnNineRouterAddKeyInputKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Enter) return;
+        e.Handled = true;
+        await ConfirmNineRouterAddKeyFromInputsAsync();
+    }
+
+    private void OnNineRouterAddKeyOverlayPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel vm) vm.DismissNineRouterAddKeyDialogCommand.Execute(null);
+    }
+
+    private async void OnNineRouterAddKeyDialogKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            vm.DismissNineRouterAddKeyDialogCommand.Execute(null);
+        }
+        else if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            await ConfirmNineRouterAddKeyFromInputsAsync();
+        }
+    }
+
     private async Task ConfirmPerplexityAccountFromInputsAsync()
     {
         if (DataContext is not MainWindowViewModel vm) return;

--- a/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
@@ -31,6 +31,7 @@
                     <ctrl:SlidingTabBar.Tabs>
                         <ctrl:SlidingTab Header="{l:Loc ProvidersView_TabCLIProxyAPI}" Command="{Binding FocusCliProxyCommand}" />
                         <ctrl:SlidingTab Header="{l:Loc ProvidersView_TabPerplexity}"  Command="{Binding FocusPerplexityCommand}" />
+                        <ctrl:SlidingTab Header="{l:Loc ProvidersView_TabNineRouter}"  Command="{Binding FocusNineRouterCommand}" />
                     </ctrl:SlidingTabBar.Tabs>
                 </ctrl:SlidingTabBar>
 
@@ -159,6 +160,80 @@
                                             <Button Grid.Column="3" Classes="icon-btn"
                                                     ToolTip.Tip="{l:Loc ProvidersView_PerplexityAccount_RemoveTooltip}"
                                                     Command="{Binding #Root.DataContext.RemovePerplexityAccountCommand}"
+                                                    CommandParameter="{Binding}">
+                                                <lucide:PackIconLucide Kind="Trash2" Width="13" Height="13"
+                                                                       Foreground="#D46A6A" />
+                                            </Button>
+                                        </Grid>
+                                    </Border>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                    </StackPanel>
+                </Border>
+
+                <Border Classes="card" IsVisible="{Binding IsNineRouterEngineSelected}" Margin="0,0,0,12">
+                    <StackPanel Margin="16,14" Spacing="12">
+                        <Grid ColumnDefinitions="*,Auto">
+                            <StackPanel>
+                                <TextBlock Classes="row-label" Text="{l:Loc ProvidersView_NineRouterSection_Title}" />
+                                <TextBlock Classes="row-desc" Text="{l:Loc ProvidersView_NineRouterSection_Description}" />
+                            </StackPanel>
+                            <Button Grid.Column="1" Classes="icon-btn"
+                                    ToolTip.Tip="{l:Loc ProvidersView_NineRouterSection_AddTooltip}"
+                                    Command="{Binding ShowAddNineRouterApiKeyCommand}"
+                                    IsEnabled="{Binding IsNineRouterEngineRunning}">
+                                <lucide:PackIconLucide Kind="Plus" Width="14" Height="14"
+                                                       Foreground="{DynamicResource FgMutedBrush}" />
+                            </Button>
+                        </Grid>
+
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectKiro}"
+                                    Command="{Binding ConnectNineRouterKiroCommand}"
+                                    IsEnabled="{Binding IsNineRouterEngineRunning}" />
+                            <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectOpenCode}"
+                                    Command="{Binding ConnectNineRouterOpenCodeFreeCommand}"
+                                    IsEnabled="{Binding IsNineRouterEngineRunning}" />
+                        </StackPanel>
+
+                        <Border Background="#08FFFFFF" CornerRadius="8" Padding="14,16"
+                                IsVisible="{Binding HasNineRouterConnections, Converter={StaticResource InvertBool}}">
+                            <StackPanel Spacing="6">
+                                <TextBlock Classes="row-label" Text="{l:Loc ProvidersView_NineRouterSection_NoConnections}" />
+                                <TextBlock Classes="row-desc" Text="{l:Loc ProvidersView_NineRouterSection_EmptyState}" TextWrapping="Wrap" />
+                            </StackPanel>
+                        </Border>
+
+                        <ItemsControl ItemsSource="{Binding NineRouterConnections}" IsVisible="{Binding HasNineRouterConnections}">
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:NineRouterConnectionViewModel">
+                                    <Border Background="#08FFFFFF" CornerRadius="8" Padding="14,12" Margin="0,0,0,8">
+                                        <Grid ColumnDefinitions="*,Auto,Auto" RowDefinitions="Auto,Auto">
+                                            <StackPanel Grid.Column="0" Grid.RowSpan="2" Spacing="4">
+                                                <StackPanel Orientation="Horizontal" Spacing="8">
+                                                    <TextBlock Classes="row-label" Text="{Binding Name}" />
+                                                    <Border Classes="chip" Background="#22FF7A00"
+                                                            IsVisible="{Binding IsActive, Converter={StaticResource InvertBool}}"
+                                                            VerticalAlignment="Center">
+                                                        <TextBlock Text="{l:Loc ProvidersView_Provider_Disabled}" Foreground="#CC7A2B" FontSize="10" />
+                                                    </Border>
+                                                </StackPanel>
+                                                <TextBlock Classes="row-desc" Text="{Binding ProviderId}"
+                                                           FontFamily="Cascadia Mono,Consolas,monospace" />
+                                                <TextBlock Classes="row-desc" Text="{Binding LastError}"
+                                                           Foreground="#D46A6A"
+                                                           TextWrapping="Wrap"
+                                                           IsVisible="{Binding HasLastError}" />
+                                            </StackPanel>
+                                            <Button Grid.Column="1" Classes="app"
+                                                    Margin="8,0,8,0"
+                                                    Content="{Binding IsActive, Converter={StaticResource BoolToEnableDisableText}}"
+                                                    Command="{Binding #Root.DataContext.ToggleNineRouterConnectionCommand}"
+                                                    CommandParameter="{Binding}" />
+                                            <Button Grid.Column="2" Classes="icon-btn"
+                                                    ToolTip.Tip="{l:Loc ProvidersView_NineRouterConnection_DeleteTooltip}"
+                                                    Command="{Binding #Root.DataContext.DeleteNineRouterConnectionCommand}"
                                                     CommandParameter="{Binding}">
                                                 <lucide:PackIconLucide Kind="Trash2" Width="13" Height="13"
                                                                        Foreground="#D46A6A" />

--- a/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
@@ -52,6 +52,48 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task FocusNineRouter_SetsProvidersTabAndFocusedEngine()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var registry = new EngineRegistryService(settings);
+        var vm = new MainWindowViewModel(settings, registry, null!, null!, null!, null!);
+
+        vm.FocusNineRouterCommand.Execute(null);
+
+        Assert.True(vm.IsNineRouterEngineSelected);
+        Assert.False(vm.IsCliProxyEngineSelected);
+        Assert.False(vm.IsPerplexityEngineSelected);
+        Assert.Equal(2, vm.ProvidersTabIndex);
+        Assert.Equal(EngineCatalog.NineRouter.Id, vm.ProvidersEngineId);
+        Assert.Equal(EngineCatalog.NineRouter.Id, vm.FocusedConfigEngineId);
+        Assert.Equal($"http://127.0.0.1:{EngineCatalog.NineRouter.DefaultPort}", vm.EndpointUrl);
+        Assert.False(vm.HasNineRouterConnections);
+    }
+
+    [Fact]
+    public async Task ShowAddNineRouterApiKey_OpensAndDismissesDialog()
+    {
+        using var temp = new TestTempDirectory();
+        var settings = new SettingsService(temp.File("settings.json"));
+        await settings.LoadAsync();
+        var registry = new EngineRegistryService(settings);
+        var vm = new MainWindowViewModel(settings, registry, null!, null!, null!, null!);
+
+        vm.ShowAddNineRouterApiKeyCommand.Execute(null);
+
+        Assert.True(vm.ShowNineRouterAddKeyDialog);
+        Assert.False(vm.ShowNineRouterAddApiKey);
+
+        vm.NineRouterAddProviderIdDraft = "openai";
+        vm.DismissNineRouterAddKeyDialogCommand.Execute(null);
+
+        Assert.False(vm.ShowNineRouterAddKeyDialog);
+        Assert.Equal("", vm.NineRouterAddProviderIdDraft);
+    }
+
+    [Fact]
     public async Task EngineService_InitialServerState_IsStopped()
     {
         using var temp = new TestTempDirectory();

--- a/tests/TunnelAgent.Tests/ModelFetchServiceTests.cs
+++ b/tests/TunnelAgent.Tests/ModelFetchServiceTests.cs
@@ -1,0 +1,58 @@
+using TunnelAgent.Core.Engine;
+using TunnelAgent.Services;
+
+namespace TunnelAgent.Tests;
+
+[Collection("UserEnvironment")]
+public sealed class ModelFetchServiceTests : IDisposable
+{
+    private readonly InMemoryUserEnvironmentService _env = new();
+    private readonly IUserEnvironmentService _previousEnv;
+
+    public ModelFetchServiceTests()
+    {
+        _previousEnv = TunnelAgent.Infrastructure.Services.UserEnvironmentService.SetImplementation(_env);
+    }
+
+    public void Dispose()
+    {
+        TunnelAgent.Infrastructure.Services.UserEnvironmentService.SetImplementation(_previousEnv);
+    }
+
+    [Fact]
+    public void ApiKeyForEngine_CliProxyApi_UsesCliproxyEnvVar()
+    {
+        _env.Set("TUNNEL_AGENT_CLIPROXY_API_KEY", "clip-key");
+        _env.Set(NineRouterClientKeyService.EnvVarName, "router-key");
+        _env.Set("TUNNEL_AGENT_PERPLEXITY_TOKEN", "pplx-token");
+
+        Assert.Equal("clip-key", ModelFetchService.ApiKeyForEngine(EngineCatalog.CliProxyApi.Id));
+        Assert.Equal("clip-key", ModelFetchService.ApiKeyForEngine(null));
+    }
+
+    [Fact]
+    public void ApiKeyForEngine_Perplexity_ReturnsEmpty()
+    {
+        _env.Set("TUNNEL_AGENT_CLIPROXY_API_KEY", "clip-key");
+        _env.Set("TUNNEL_AGENT_PERPLEXITY_TOKEN", "pplx-token");
+
+        Assert.Equal("", ModelFetchService.ApiKeyForEngine(EngineCatalog.PerplexityWebUiScraper.Id));
+    }
+
+    [Fact]
+    public void ApiKeyForEngine_NineRouter_UsesNineRouterEnvVar()
+    {
+        _env.Set("TUNNEL_AGENT_CLIPROXY_API_KEY", "clip-key");
+        _env.Set(NineRouterClientKeyService.EnvVarName, "router-key");
+
+        Assert.Equal("router-key", ModelFetchService.ApiKeyForEngine(EngineCatalog.NineRouter.Id));
+    }
+
+    private sealed class InMemoryUserEnvironmentService : IUserEnvironmentService
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+        public string? Get(string name) => _values.TryGetValue(name, out var v) ? v : null;
+        public void Set(string name, string value) => _values[name] = value;
+        public void Remove(string name) => _values.Remove(name);
+    }
+}

--- a/tests/TunnelAgent.Tests/NineRouterClientKeyServiceTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterClientKeyServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+using TunnelAgent.Services;
+
+namespace TunnelAgent.Tests;
+
+[Collection("UserEnvironment")]
+public sealed class NineRouterClientKeyServiceTests : IDisposable
+{
+    private readonly InMemoryUserEnvironmentService _env = new();
+    private readonly IUserEnvironmentService _previousEnv;
+    private readonly NineRouterClientKeyService _service = new();
+
+    public NineRouterClientKeyServiceTests()
+    {
+        _previousEnv = TunnelAgent.Infrastructure.Services.UserEnvironmentService.SetImplementation(_env);
+    }
+
+    public void Dispose()
+    {
+        TunnelAgent.Infrastructure.Services.UserEnvironmentService.SetImplementation(_previousEnv);
+    }
+
+    [Fact]
+    public async Task EnsureUserApiKeyAsync_EnvAlreadySet_DoesNotCallApi()
+    {
+        _env.Set(NineRouterClientKeyService.EnvVarName, "existing-key");
+        using var handler = new FakeApiHandler();
+        using var client = new ApiClient(20128, handler);
+
+        await _service.EnsureUserApiKeyAsync(client);
+
+        Assert.Empty(handler.Requests);
+        Assert.Equal("existing-key", _env.Get(NineRouterClientKeyService.EnvVarName));
+    }
+
+    [Fact]
+    public async Task EnsureUserApiKeyAsync_ExistingListedKey_SetsEnvWithoutCreate()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "keys": [ { "id": "k1", "name": "Existing", "key": "listed-secret", "isActive": true } ] }
+            """);
+        using var client = new ApiClient(20128, handler);
+
+        await _service.EnsureUserApiKeyAsync(client);
+
+        Assert.Equal("listed-secret", _env.Get(NineRouterClientKeyService.EnvVarName));
+        Assert.Single(handler.Requests);
+        Assert.Equal("/api/keys", handler.Requests[0].Path);
+        Assert.Equal("GET", handler.Requests[0].Method);
+    }
+
+    [Fact]
+    public async Task EnsureUserApiKeyAsync_NoKeys_CreatesTunnelAgentKey()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "keys": [] }""");
+        handler.EnqueueJson(HttpStatusCode.Created, """
+            { "id": "k-new", "name": "Tunnel Agent", "key": "created-secret", "machineId": "m1" }
+            """);
+        using var client = new ApiClient(20128, handler);
+
+        await _service.EnsureUserApiKeyAsync(client);
+
+        Assert.Equal("created-secret", _env.Get(NineRouterClientKeyService.EnvVarName));
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("POST", handler.Requests[1].Method);
+        Assert.Equal("/api/keys", handler.Requests[1].Path);
+        using var body = JsonDocument.Parse(handler.Requests[1].Body!);
+        Assert.Equal(NineRouterClientKeyService.DefaultKeyName, body.RootElement.GetProperty("name").GetString());
+    }
+
+    private sealed class InMemoryUserEnvironmentService : IUserEnvironmentService
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+        public string? Get(string name) => _values.TryGetValue(name, out var v) ? v : null;
+        public void Set(string name, string value) => _values[name] = value;
+        public void Remove(string name) => _values.Remove(name);
+    }
+
+    private sealed class FakeApiHandler : HttpMessageHandler
+    {
+        private readonly Queue<Func<HttpResponseMessage>> _responses = new();
+        public List<CapturedRequest> Requests { get; } = [];
+
+        public void EnqueueJson(HttpStatusCode status, string json)
+        {
+            _responses.Enqueue(() => new HttpResponseMessage(status)
+            {
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string? body = null;
+            if (request.Content is not null)
+                body = await request.Content.ReadAsStringAsync(cancellationToken);
+
+            var uri = request.RequestUri ?? throw new InvalidOperationException("Request URI was null.");
+            var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
+            if (!path.StartsWith('/'))
+                path = "/" + path.TrimStart('/');
+
+            Requests.Add(new CapturedRequest(request.Method.Method, path, string.IsNullOrEmpty(body) ? null : body));
+            if (_responses.Count == 0)
+                throw new InvalidOperationException($"Unexpected {request.Method} {path}");
+            return _responses.Dequeue()();
+        }
+    }
+
+    private sealed record CapturedRequest(string Method, string Path, string? Body);
+}

--- a/tests/TunnelAgent.Tests/PerplexityAccountCatalogServiceTests.cs
+++ b/tests/TunnelAgent.Tests/PerplexityAccountCatalogServiceTests.cs
@@ -3,6 +3,7 @@ using TunnelAgent.Services;
 
 namespace TunnelAgent.Tests;
 
+[Collection("UserEnvironment")]
 public sealed class PerplexityAccountCatalogServiceTests : IDisposable
 {
     private readonly InMemoryUserEnvironmentService _env = new();

--- a/tests/TunnelAgent.Tests/ViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/ViewModelTests.cs
@@ -255,4 +255,26 @@ public sealed class ViewModelTests
         Assert.False(vm.IsExpanded);
         Assert.False(raised);
     }
+
+    [Fact]
+    public void NineRouterConnectionViewModel_Constructor_MapsAllProperties()
+    {
+        var vm = new NineRouterConnectionViewModel("conn-1", "openai", "My OpenAI", isActive: false, lastError: "quota");
+
+        Assert.Equal("conn-1", vm.Id);
+        Assert.Equal("openai", vm.ProviderId);
+        Assert.Equal("My OpenAI", vm.Name);
+        Assert.False(vm.IsActive);
+        Assert.Equal("quota", vm.LastError);
+        Assert.True(vm.HasLastError);
+    }
+
+    [Fact]
+    public void NineRouterConnectionViewModel_EmptyName_FallsBackToProviderId()
+    {
+        var vm = new NineRouterConnectionViewModel("id", "kiro", "", isActive: true, lastError: null);
+
+        Assert.Equal("kiro", vm.Name);
+        Assert.False(vm.HasLastError);
+    }
 }


### PR DESCRIPTION
List, add API-key and free providers, and fetch models from the running 9Router engine.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>