### PR TITLE
feat: connect Claude, Gemini, and Copilot via 9Router OAuth

### DIFF
--- a/docs/plan/2026-08-14-9router-engine.md
+++ b/docs/plan/2026-08-14-9router-engine.md
@@ -409,3 +409,19 @@ Enabled/disabled is `isActive`, not `enabled`/`disabled`. 9Router sets `authType
 | --- | --- | --- | --- |
 | GET | `/api/keys` | — | `200` `{ "keys": [ { id, name, key, machineId, isActive, createdAt } ] }` |
 | POST | `/api/keys` | `{ "name": "..." }` | `201` `{ "id", "name", "key", "machineId" }` |
+
+---
+
+## Phase 10 OAuth contract
+
+Captured from [decolua/9router](https://github.com/decolua/9router) `master` (`src/app/api/oauth/[provider]/[action]/route.js`, `src/lib/oauth/providers/index.js`, dashboard `OAuthModal.js`). Cookie auth retry is the same as Phase 7.
+
+Curated provider ids (do not use `copilot` / `github-copilot` / `gemini`):
+
+| Button | 9Router id | Flow |
+| --- | --- | --- |
+| Connect Claude | `claude` | `GET /api/oauth/claude/authorize?redirect_uri=...` → open `authUrl` → loopback captures `code` → `POST /api/oauth/claude/exchange` `{ code, redirectUri, codeVerifier, state }` |
+| Connect Gemini | `gemini-cli` | Same authorize + exchange pattern (`flowType`: `authorization_code`) |
+| Connect Copilot | `github` | `GET /api/oauth/github/device-code` → open `verification_uri_complete` (fallback `verification_uri`) → `POST /api/oauth/github/poll` `{ deviceCode }` until `{ success: true, connection }` |
+
+Authorize JSON (camelCase): `{ authUrl, state, codeVerifier, redirectUri, flowType }`. Device-code JSON is GitHub snake_case plus optional `codeVerifier`: `{ device_code, verification_uri, verification_uri_complete, interval, expires_in }`. Poll pending: `{ success: false, pending: true, error: "authorization_pending" }`. Default wait is ~2.5 minutes. Secrets (`code`, `codeVerifier`, `deviceCode`) are never logged.

--- a/src/TunnelAgent.Avalonia/Resources/Strings.ar-SA.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.ar-SA.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>توصيل OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>توصيل Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>توصيل Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>توصيل Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>أكمل تسجيل الدخول إلى {0} في المتصفح.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>تم توصيل {0}.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>تعذر توصيل {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>انتهت مهلة تسجيل الدخول إلى {0}. أعد المحاولة بعد الإكمال في المتصفح.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>حذف الاتصال</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.de-DE.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.de-DE.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>OpenCode Free verbinden</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Claude verbinden</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Gemini verbinden</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Copilot verbinden</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Melden Sie sich im Browser bei {0} an.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} ist verbunden.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>{0} konnte nicht verbunden werden: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>Die Anmeldung bei {0} ist abgelaufen. Nach dem Abschluss im Browser erneut versuchen.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Verbindung löschen</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
@@ -573,6 +573,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Conectar OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Conectar Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Conectar Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Conectar Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Termina de iniciar sesión en {0} en el navegador.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} está conectado.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>No se pudo conectar {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>El inicio de sesión de {0} agotó el tiempo. Vuelve a intentarlo después de terminar en el navegador.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Eliminar conexión</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.fr-FR.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.fr-FR.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Connecter OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Connecter Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Connecter Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Connecter Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Terminez la connexion à {0} dans le navigateur.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} est connecté.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>Impossible de connecter {0} : {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>La connexion à {0} a expiré. Réessayez après avoir terminé dans le navigateur.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Supprimer la connexion</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.hi-IN.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.hi-IN.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>OpenCode Free कनेक्ट करें</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Claude कनेक्ट करें</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Gemini कनेक्ट करें</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Copilot कनेक्ट करें</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>ब्राउज़र में {0} साइन-इन पूरा करें।</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} कनेक्ट हो गया है।</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>{0} कनेक्ट नहीं हो सका: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>{0} साइन-इन समय समाप्त। ब्राउज़र में पूरा करने के बाद फिर कोशिश करें।</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>कनेक्शन हटाएँ</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.it-IT.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.it-IT.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Connetti OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Connetti Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Connetti Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Connetti Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Completa l'accesso a {0} nel browser.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} è connesso.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>Impossibile connettere {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>Accesso a {0} scaduto. Riprova dopo aver completato nel browser.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Elimina connessione</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.ja-JP.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.ja-JP.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>OpenCode Free を接続</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Claude を接続</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Gemini を接続</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Copilot を接続</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>ブラウザで {0} のサインインを完了してください。</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} を接続しました。</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>{0} を接続できませんでした: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>{0} のサインインがタイムアウトしました。ブラウザで完了してから再試行してください。</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>接続を削除</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.ko-KR.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.ko-KR.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>OpenCode Free 연결</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Claude 연결</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Gemini 연결</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Copilot 연결</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>브라우저에서 {0} 로그인을 완료하세요.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0}이(가) 연결되었습니다.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>{0}을(를) 연결할 수 없습니다: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>{0} 로그인이 시간 초과되었습니다. 브라우저에서 완료한 뒤 다시 시도하세요.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>연결 삭제</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.pt-PT.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.pt-PT.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Ligar OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Ligar Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Ligar Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Ligar Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Conclua o início de sessão em {0} no browser.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} está ligado.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>Não foi possível ligar {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>O início de sessão em {0} expirou. Tente novamente depois de concluir no browser.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Eliminar ligação</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -585,6 +585,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Connect OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Connect Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Connect Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Connect Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Finish signing in to {0} in the browser.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} is connected.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>Could not connect {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>{0} sign-in timed out. Try again after finishing in the browser.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Delete connection</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.ru-RU.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.ru-RU.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Подключить OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Подключить Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Подключить Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Подключить Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Завершите вход в {0} в браузере.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} подключён.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>Не удалось подключить {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>Вход в {0} истек. Повторите после завершения в браузере.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Удалить подключение</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.tr-TR.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.tr-TR.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>OpenCode Free bağla</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Claude bağla</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Gemini bağla</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Copilot bağla</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Tarayıcıda {0} oturumunu tamamlayın.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} bağlandı.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>{0} bağlanamadı: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>{0} oturumu zaman aşımına uğradı. Tarayıcıda bitirdikten sonra yeniden deneyin.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Bağlantıyı sil</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.uk-UA.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.uk-UA.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>Підключити OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>Підключити Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>Підключити Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>Підключити Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>Завершіть вхід у {0} у браузері.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>{0} підключено.</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>Не вдалося підключити {0}: {1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>Час входу в {0} вичерпано. Спробуйте знову після завершення в браузері.</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Видалити підключення</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.zh-CN.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.zh-CN.resx
@@ -582,6 +582,27 @@
   <data name="ProvidersView_NineRouterSection_ConnectOpenCode" xml:space="preserve">
     <value>连接 OpenCode Free</value>
   </data>
+  <data name="ProvidersView_NineRouterSection_ConnectClaude" xml:space="preserve">
+    <value>连接 Claude</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectGemini" xml:space="preserve">
+    <value>连接 Gemini</value>
+  </data>
+  <data name="ProvidersView_NineRouterSection_ConnectCopilot" xml:space="preserve">
+    <value>连接 Copilot</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthWaiting" xml:space="preserve">
+    <value>请在浏览器中完成 {0} 登录。</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthConnected" xml:space="preserve">
+    <value>已连接 {0}。</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthFailed" xml:space="preserve">
+    <value>无法连接 {0}：{1}</value>
+  </data>
+  <data name="ProvidersView_NineRouter_OAuthTimeout" xml:space="preserve">
+    <value>{0} 登录超时。请在浏览器中完成后再试。</value>
+  </data>
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>删除连接</value>
   </data>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
+using System.Net;
 using System.Net.Mail;
 using System.Threading;
 using System.Threading.Tasks;
@@ -2501,6 +2502,110 @@ SelectedSection is SectionKey.Logs;
     [RelayCommand]
     private Task ConnectNineRouterKiroAsync() =>
         CreateNineRouterProviderAsync("kiro", "Kiro AI", NoAuthApiKeyPlaceholder);
+
+    [RelayCommand]
+    private Task ConnectNineRouterClaudeAsync() =>
+        ConnectNineRouterOAuthAsync(NineRouterOAuthProviders.Claude, "Claude");
+
+    [RelayCommand]
+    private Task ConnectNineRouterGeminiAsync() =>
+        ConnectNineRouterOAuthAsync(NineRouterOAuthProviders.GeminiCli, "Gemini");
+
+    [RelayCommand]
+    private Task ConnectNineRouterCopilotAsync() =>
+        ConnectNineRouterOAuthAsync(NineRouterOAuthProviders.GitHub, "Copilot");
+
+    private async Task ConnectNineRouterOAuthAsync(string providerId, string displayName)
+    {
+        if (!IsNineRouterEngineRunning)
+        {
+            ShowNineRouterStatus(_localization.GetString("ProvidersView_NineRouter_EngineNotRunning"), isError: true);
+            return;
+        }
+
+        if (IsNineRouterBusy) return;
+        IsNineRouterBusy = true;
+        try
+        {
+            using var client = new ApiClient(NineRouterEngine.Port);
+            using var timeoutCts = new CancellationTokenSource(NineRouterOAuthProviders.DefaultTimeout);
+
+            if (NineRouterOAuthProviders.IsDeviceCode(providerId))
+            {
+                var start = await client.StartOAuthAsync(providerId, redirectUri: null, timeoutCts.Token);
+                OpenNineRouterOAuthUrl(start.BrowserUrl!);
+                ShowNineRouterStatus(
+                    _localization.GetString("ProvidersView_NineRouter_OAuthWaiting", displayName),
+                    isError: false);
+                if (string.IsNullOrWhiteSpace(start.DeviceCode))
+                {
+                    throw new NineRouterApiException(
+                        HttpStatusCode.BadRequest,
+                        "OAuth start did not return a device code.");
+                }
+
+                await client.PollOAuthUntilConnectedAsync(
+                    providerId,
+                    start.DeviceCode,
+                    start.CodeVerifier,
+                    NineRouterOAuthProviders.DefaultTimeout,
+                    TimeSpan.FromSeconds(Math.Max(1, start.IntervalSeconds)),
+                    timeoutCts.Token);
+            }
+            else
+            {
+                using var listener = OAuthCallbackListener.Start();
+                var start = await client.StartOAuthAsync(providerId, listener.RedirectUri, timeoutCts.Token);
+                OpenNineRouterOAuthUrl(start.BrowserUrl!);
+                ShowNineRouterStatus(
+                    _localization.GetString("ProvidersView_NineRouter_OAuthWaiting", displayName),
+                    isError: false);
+                var code = await listener.WaitForCodeAsync(NineRouterOAuthProviders.DefaultTimeout, timeoutCts.Token);
+                await client.ExchangeOAuthAsync(
+                    providerId,
+                    code,
+                    start.RedirectUri ?? listener.RedirectUri,
+                    start.CodeVerifier,
+                    start.State,
+                    timeoutCts.Token);
+            }
+
+            await RefreshNineRouterConnectionsAsync();
+            RestartNineRouterModelFetch();
+            ShowNineRouterStatus(
+                _localization.GetString("ProvidersView_NineRouter_OAuthConnected", displayName),
+                isError: false);
+        }
+        catch (Exception ex) when (ex is OperationCanceledException)
+        {
+            ShowNineRouterStatus(
+                _localization.GetString("ProvidersView_NineRouter_OAuthTimeout", displayName),
+                isError: true);
+        }
+        catch (NineRouterApiException ex)
+        {
+            ShowNineRouterStatus(
+                ex.StatusCode == HttpStatusCode.RequestTimeout
+                    ? _localization.GetString("ProvidersView_NineRouter_OAuthTimeout", displayName)
+                    : _localization.GetString("ProvidersView_NineRouter_OAuthFailed", displayName, ex.Message),
+                isError: true);
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(
+                _localization.GetString("ProvidersView_NineRouter_OAuthFailed", displayName, ex.Message),
+                isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    private static void OpenNineRouterOAuthUrl(string url)
+    {
+        Process.Start(new ProcessStartInfo { FileName = url, UseShellExecute = true });
+    }
 
     [RelayCommand]
     private async Task ConnectNineRouterOpenCodeFreeAsync()

--- a/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
@@ -188,14 +188,23 @@
                             </Button>
                         </Grid>
 
-                        <StackPanel Orientation="Horizontal" Spacing="8">
+                        <WrapPanel Orientation="Horizontal" ItemSpacing="8" LineSpacing="8">
                             <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectKiro}"
                                     Command="{Binding ConnectNineRouterKiroCommand}"
                                     IsEnabled="{Binding IsNineRouterEngineRunning}" />
                             <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectOpenCode}"
                                     Command="{Binding ConnectNineRouterOpenCodeFreeCommand}"
                                     IsEnabled="{Binding IsNineRouterEngineRunning}" />
-                        </StackPanel>
+                            <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectClaude}"
+                                    Command="{Binding ConnectNineRouterClaudeCommand}"
+                                    IsEnabled="{Binding IsNineRouterEngineRunning}" />
+                            <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectGemini}"
+                                    Command="{Binding ConnectNineRouterGeminiCommand}"
+                                    IsEnabled="{Binding IsNineRouterEngineRunning}" />
+                            <Button Classes="app" Content="{l:Loc ProvidersView_NineRouterSection_ConnectCopilot}"
+                                    Command="{Binding ConnectNineRouterCopilotCommand}"
+                                    IsEnabled="{Binding IsNineRouterEngineRunning}" />
+                        </WrapPanel>
 
                         <Border Background="#08FFFFFF" CornerRadius="8" Padding="14,16"
                                 IsVisible="{Binding HasNineRouterConnections, Converter={StaticResource InvertBool}}">

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -13,8 +13,8 @@ namespace TunnelAgent.Infrastructure.Engine.NineRouter;
 
 /// <summary>
 /// HTTP client for 9Router's local dashboard management API
-/// (<c>http://127.0.0.1:{port}/api/...</c>). Talks to <c>/api/providers</c> and
-/// <c>/api/keys</c> instead of writing SQLite.
+/// (<c>http://127.0.0.1:{port}/api/...</c>). Talks to <c>/api/providers</c>,
+/// <c>/api/keys</c>, and <c>/api/oauth/{provider}/{action}</c> instead of writing SQLite.
 /// </summary>
 /// <remarks>
 /// Recent 9Router builds require an <c>auth_token</c> cookie on
@@ -183,6 +183,168 @@ public sealed class ApiClient : IDisposable
             .ConfigureAwait(false);
         var payload = await ReadJsonAsync<KeyListResponse>(response, ct).ConfigureAwait(false);
         return payload.Keys ?? [];
+    }
+
+    /// <summary>
+    /// Starts a curated OAuth flow via <c>GET /api/oauth/{provider}/authorize</c>
+    /// (Claude, Gemini CLI) or <c>GET /api/oauth/{provider}/device-code</c>
+    /// (GitHub Copilot).
+    /// </summary>
+    /// <param name="providerId">9Router provider id (<c>claude</c>, <c>gemini-cli</c>, or <c>github</c>).</param>
+    /// <param name="redirectUri">
+    /// Loopback callback URI for authorize flows. Ignored for GitHub device-code.
+    /// Defaults to <c>http://127.0.0.1:{port}/callback</c>.
+    /// </param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    /// <returns>Browser URL plus PKCE/device fields needed to finish the flow.</returns>
+    public async Task<NineRouterOAuthStartResult> StartOAuthAsync(
+        string providerId,
+        string? redirectUri = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerId);
+        var path = NineRouterOAuthProviders.IsDeviceCode(providerId)
+            ? OAuthPath(providerId, "device-code")
+            : OAuthPath(providerId, "authorize") + "?redirect_uri=" +
+              Uri.EscapeDataString(string.IsNullOrWhiteSpace(redirectUri)
+                  ? $"http://127.0.0.1:{Port}/callback"
+                  : redirectUri);
+
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Get, path, body: null, ct)
+            .ConfigureAwait(false);
+        var root = await ReadJsonAsync<JsonElement>(response, ct).ConfigureAwait(false);
+        var browserUrl = JsonString(root, "authUrl", "verification_uri_complete", "verification_uri");
+        if (string.IsNullOrWhiteSpace(browserUrl))
+        {
+            throw new NineRouterApiException(
+                response.StatusCode,
+                "OAuth start did not return a browser URL.");
+        }
+
+        return new NineRouterOAuthStartResult
+        {
+            Provider = providerId,
+            FlowType = JsonString(root, "flowType"),
+            BrowserUrl = browserUrl,
+            State = JsonString(root, "state"),
+            CodeVerifier = JsonString(root, "codeVerifier"),
+            RedirectUri = JsonString(root, "redirectUri") ?? redirectUri,
+            DeviceCode = JsonString(root, "device_code", "deviceCode"),
+            IntervalSeconds = JsonInt(root, "interval") is { } interval and > 0 ? interval : 5
+        };
+    }
+
+    /// <summary>
+    /// One device-code poll via <c>POST /api/oauth/{provider}/poll</c>.
+    /// Pending authorization returns <see cref="NineRouterOAuthPollResult.Pending"/> instead of throwing.
+    /// </summary>
+    /// <param name="providerId">9Router provider id (typically <c>github</c>).</param>
+    /// <param name="deviceCode">Device code from <see cref="StartOAuthAsync"/>.</param>
+    /// <param name="codeVerifier">PKCE verifier when the provider uses one.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterOAuthPollResult> PollOAuthAsync(
+        string providerId,
+        string deviceCode,
+        string? codeVerifier = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(deviceCode);
+        using var response = await SendWithAuthRetryAsync(
+                HttpMethod.Post,
+                OAuthPath(providerId, "poll"),
+                new OAuthPollRequest(deviceCode, codeVerifier),
+                ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<OAuthPollResponse>(response, ct).ConfigureAwait(false);
+        var pending = payload.Pending
+            || string.Equals(payload.Error, "authorization_pending", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(payload.Error, "slow_down", StringComparison.OrdinalIgnoreCase);
+        var error = string.IsNullOrWhiteSpace(payload.ErrorDescription) ? payload.Error : payload.ErrorDescription;
+        return new NineRouterOAuthPollResult(payload.Success, pending, error, payload.Connection);
+    }
+
+    /// <summary>
+    /// Polls <c>POST /api/oauth/{provider}/poll</c> until 9Router stores a connection or
+    /// <paramref name="timeout"/> elapses.
+    /// </summary>
+    /// <param name="providerId">9Router provider id (typically <c>github</c>).</param>
+    /// <param name="deviceCode">Device code from <see cref="StartOAuthAsync"/>.</param>
+    /// <param name="codeVerifier">PKCE verifier when the provider uses one.</param>
+    /// <param name="timeout">Maximum time to wait (about 2–3 minutes from the UI).</param>
+    /// <param name="pollInterval">Delay between polls. Defaults to 5 seconds.</param>
+    /// <param name="ct">Token used to cancel the wait.</param>
+    public async Task<NineRouterProvider> PollOAuthUntilConnectedAsync(
+        string providerId,
+        string deviceCode,
+        string? codeVerifier,
+        TimeSpan timeout,
+        TimeSpan? pollInterval = null,
+        CancellationToken ct = default)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        var interval = pollInterval ?? TimeSpan.FromSeconds(5);
+
+        while (true)
+        {
+            ct.ThrowIfCancellationRequested();
+            var result = await PollOAuthAsync(providerId, deviceCode, codeVerifier, ct).ConfigureAwait(false);
+            if (result.Success)
+            {
+                return result.Connection
+                    ?? throw new NineRouterApiException(
+                        HttpStatusCode.OK,
+                        "OAuth succeeded but the response did not include a connection.");
+            }
+
+            if (!result.Pending)
+            {
+                throw new NineRouterApiException(
+                    HttpStatusCode.BadRequest,
+                    result.Error ?? "OAuth poll failed.");
+            }
+
+            if (DateTime.UtcNow + interval >= deadline)
+            {
+                throw new NineRouterApiException(
+                    HttpStatusCode.RequestTimeout,
+                    "OAuth timed out before the connection was saved.");
+            }
+
+            await Task.Delay(interval, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Exchanges an authorization code via <c>POST /api/oauth/{provider}/exchange</c>
+    /// and stores the connection. Request bodies are never logged.
+    /// </summary>
+    /// <param name="providerId">9Router provider id (<c>claude</c> or <c>gemini-cli</c>).</param>
+    /// <param name="code">Authorization code from the loopback redirect.</param>
+    /// <param name="redirectUri">The same redirect URI passed to <see cref="StartOAuthAsync"/>.</param>
+    /// <param name="codeVerifier">PKCE verifier from start (required for Claude).</param>
+    /// <param name="state">OAuth state from start, when present.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterProvider> ExchangeOAuthAsync(
+        string providerId,
+        string code,
+        string redirectUri,
+        string? codeVerifier,
+        string? state,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(providerId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(code);
+        ArgumentException.ThrowIfNullOrWhiteSpace(redirectUri);
+        using var response = await SendWithAuthRetryAsync(
+                HttpMethod.Post,
+                OAuthPath(providerId, "exchange"),
+                new OAuthExchangeRequest(code, redirectUri, codeVerifier, state),
+                ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<OAuthExchangeResponse>(response, ct).ConfigureAwait(false);
+        return payload.Connection
+            ?? throw new NineRouterApiException(response.StatusCode, "OAuth exchange did not include a connection.");
     }
 
     /// <summary>Creates a client API key via <c>POST /api/keys</c> with <c>{"name":"..."}</c>.</summary>
@@ -380,6 +542,37 @@ public sealed class ApiClient : IDisposable
     private static string ProviderPath(string id) =>
         "api/providers/" + Uri.EscapeDataString(id);
 
+    private static string OAuthPath(string providerId, string action) =>
+        "api/oauth/" + Uri.EscapeDataString(providerId) + "/" + action;
+
+    private static string? JsonString(JsonElement root, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!root.TryGetProperty(name, out var property))
+                continue;
+            if (property.ValueKind == JsonValueKind.String)
+                return property.GetString();
+        }
+
+        return null;
+    }
+
+    private static int? JsonInt(JsonElement root, params string[] names)
+    {
+        foreach (var name in names)
+        {
+            if (!root.TryGetProperty(name, out var property))
+                continue;
+            if (property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out var value))
+                return value;
+            if (property.ValueKind == JsonValueKind.String && int.TryParse(property.GetString(), out var parsed))
+                return parsed;
+        }
+
+        return null;
+    }
+
     private sealed record ProviderListResponse(List<NineRouterProvider>? Connections, string? Error);
 
     private sealed record ProviderEnvelope(NineRouterProvider? Connection, string? Error);
@@ -397,4 +590,17 @@ public sealed class ApiClient : IDisposable
     private sealed record LoginResponse(bool Success, string? Error);
 
     private sealed record ErrorResponse(string? Error);
+
+    private sealed record OAuthPollRequest(string DeviceCode, string? CodeVerifier);
+
+    private sealed record OAuthPollResponse(
+        bool Success,
+        bool Pending,
+        string? Error,
+        string? ErrorDescription,
+        NineRouterProvider? Connection);
+
+    private sealed record OAuthExchangeRequest(string Code, string RedirectUri, string? CodeVerifier, string? State);
+
+    private sealed record OAuthExchangeResponse(bool Success, NineRouterProvider? Connection, string? Error);
 }

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -189,3 +189,71 @@ public sealed record NineRouterCreatedApiKey
     /// <summary>Gets the machine id the key is bound to.</summary>
     public string? MachineId { get; init; }
 }
+
+/// <summary>
+/// Curated 9Router OAuth provider ids used by Tunnel Agent
+/// (Claude, Gemini CLI, GitHub Copilot).
+/// </summary>
+public static class NineRouterOAuthProviders
+{
+    /// <summary>Claude Code OAuth (<c>authorization_code_pkce</c>).</summary>
+    public const string Claude = "claude";
+
+    /// <summary>Gemini CLI OAuth (<c>authorization_code</c>).</summary>
+    public const string GeminiCli = "gemini-cli";
+
+    /// <summary>GitHub Copilot OAuth (<c>device_code</c>). Stored as provider id <c>github</c>.</summary>
+    public const string GitHub = "github";
+
+    /// <summary>Default wait for the user to finish browser sign-in.</summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(2.5);
+
+    /// <summary>Whether <paramref name="providerId"/> uses GitHub device-code instead of a redirect.</summary>
+    public static bool IsDeviceCode(string providerId) =>
+        string.Equals(providerId, GitHub, StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Result of starting a 9Router OAuth flow
+/// (<c>GET /api/oauth/{provider}/authorize</c> or <c>.../device-code</c>).
+/// </summary>
+public sealed record NineRouterOAuthStartResult
+{
+    /// <summary>Gets the 9Router provider id used in the request path.</summary>
+    public required string Provider { get; init; }
+
+    /// <summary>Gets the flow type when 9Router included it (<c>authorization_code_pkce</c>, <c>device_code</c>, …).</summary>
+    public string? FlowType { get; init; }
+
+    /// <summary>
+    /// Gets the URL to open in the system browser: <c>authUrl</c> for authorize
+    /// flows, or <c>verification_uri_complete</c> / <c>verification_uri</c> for device code.
+    /// </summary>
+    public string? BrowserUrl { get; init; }
+
+    /// <summary>Gets the PKCE/OAuth state to send back on exchange.</summary>
+    public string? State { get; init; }
+
+    /// <summary>Gets the PKCE verifier. Never logged by <see cref="ApiClient"/>.</summary>
+    public string? CodeVerifier { get; init; }
+
+    /// <summary>Gets the redirect URI registered for this authorize request.</summary>
+    public string? RedirectUri { get; init; }
+
+    /// <summary>Gets the device code for <c>POST .../poll</c>. Never logged by <see cref="ApiClient"/>.</summary>
+    public string? DeviceCode { get; init; }
+
+    /// <summary>Gets the suggested poll interval in seconds (GitHub default is 5).</summary>
+    public int IntervalSeconds { get; init; } = 5;
+}
+
+/// <summary>Result of one <c>POST /api/oauth/{provider}/poll</c> attempt.</summary>
+/// <param name="Success">Whether 9Router stored a connection.</param>
+/// <param name="Pending">Whether the user has not finished authorizing yet.</param>
+/// <param name="Error">Failure or pending error code/description from 9Router.</param>
+/// <param name="Connection">The new connection when <paramref name="Success"/> is true.</param>
+public sealed record NineRouterOAuthPollResult(
+    bool Success,
+    bool Pending,
+    string? Error,
+    NineRouterProvider? Connection);

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/OAuthCallbackListener.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/OAuthCallbackListener.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TunnelAgent.Infrastructure.Engine.NineRouter;
+
+/// <summary>
+/// Loopback HTTP listener that captures an OAuth authorization <c>code</c> from
+/// the provider redirect. Used for Claude and Gemini CLI; GitHub Copilot uses
+/// device-code polling instead.
+/// </summary>
+public sealed class OAuthCallbackListener : IDisposable
+{
+    private readonly TcpListener _listener;
+    private bool _disposed;
+
+    private OAuthCallbackListener(TcpListener listener, string redirectUri)
+    {
+        _listener = listener;
+        RedirectUri = redirectUri;
+    }
+
+    /// <summary>Gets the <c>http://127.0.0.1:{port}/callback</c> redirect URI.</summary>
+    public string RedirectUri { get; }
+
+    /// <summary>Binds a loopback port and starts accepting one callback request.</summary>
+    public static OAuthCallbackListener Start()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        return new OAuthCallbackListener(listener, $"http://127.0.0.1:{port}/callback");
+    }
+
+    /// <summary>
+    /// Waits for the browser redirect and returns the authorization code.
+    /// Does not log the code.
+    /// </summary>
+    /// <param name="timeout">How long to wait for the redirect.</param>
+    /// <param name="ct">Token used to cancel the wait.</param>
+    /// <returns>The <c>code</c> query value.</returns>
+    public async Task<string> WaitForCodeAsync(TimeSpan timeout, CancellationToken ct = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        linked.CancelAfter(timeout);
+
+        TcpClient client;
+        try
+        {
+            client = await _listener.AcceptTcpClientAsync(linked.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
+        {
+            throw new NineRouterApiException(
+                HttpStatusCode.RequestTimeout,
+                "OAuth timed out before the browser redirect arrived.");
+        }
+
+        using (client)
+        {
+            client.ReceiveTimeout = (int)Math.Clamp(timeout.TotalMilliseconds, 1, int.MaxValue);
+            using var stream = client.GetStream();
+            var request = await ReadHttpRequestAsync(stream, linked.Token).ConfigureAwait(false);
+            var query = ParseRequestTarget(request);
+            query.TryGetValue("error", out var error);
+            if (!string.IsNullOrEmpty(error))
+            {
+                query.TryGetValue("error_description", out var description);
+                await WriteHtmlAsync(stream, "Authorization was denied.", linked.Token).ConfigureAwait(false);
+                throw new NineRouterApiException(
+                    HttpStatusCode.BadRequest,
+                    string.IsNullOrWhiteSpace(description) ? error : description);
+            }
+
+            query.TryGetValue("code", out var code);
+            if (string.IsNullOrWhiteSpace(code))
+            {
+                await WriteHtmlAsync(stream, "Missing authorization code.", linked.Token).ConfigureAwait(false);
+                throw new NineRouterApiException(HttpStatusCode.BadRequest, "OAuth redirect did not include an authorization code.");
+            }
+
+            await WriteHtmlAsync(stream, "You can close this window and return to Tunnel Agent.", linked.Token)
+                .ConfigureAwait(false);
+            return code;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+        _disposed = true;
+        try
+        {
+            _listener.Stop();
+        }
+        catch (SocketException)
+        {
+            // Already stopped.
+        }
+    }
+
+    private static async Task<string> ReadHttpRequestAsync(NetworkStream stream, CancellationToken ct)
+    {
+        var buffer = new byte[8192];
+        using var ms = new MemoryStream();
+        while (ms.Length < 8192)
+        {
+            var read = await stream.ReadAsync(buffer, ct).ConfigureAwait(false);
+            if (read <= 0)
+                break;
+            ms.Write(buffer, 0, read);
+            var text = Encoding.ASCII.GetString(ms.GetBuffer(), 0, (int)ms.Length);
+            if (text.Contains("\r\n\r\n", StringComparison.Ordinal))
+                return text;
+        }
+
+        throw new NineRouterApiException(HttpStatusCode.BadRequest, "OAuth callback request was empty or incomplete.");
+    }
+
+    private static Dictionary<string, string> ParseRequestTarget(string request)
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var firstLine = request.Split('\r', '\n')[0];
+        var parts = firstLine.Split(' ');
+        if (parts.Length < 2)
+            return result;
+
+        var target = parts[1];
+        var q = target.IndexOf('?', StringComparison.Ordinal);
+        if (q < 0)
+            return result;
+
+        var query = target[(q + 1)..];
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            if (eq <= 0)
+                continue;
+            var key = Uri.UnescapeDataString(pair[..eq].Replace('+', ' '));
+            var value = Uri.UnescapeDataString(pair[(eq + 1)..].Replace('+', ' '));
+            result[key] = value;
+        }
+
+        return result;
+    }
+
+    private static async Task WriteHtmlAsync(NetworkStream stream, string message, CancellationToken ct)
+    {
+        var body = "<!DOCTYPE html><html><body><p>" + WebUtility.HtmlEncode(message) + "</p></body></html>";
+        var bytes = Encoding.UTF8.GetBytes(body);
+        var header =
+            "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: text/html; charset=utf-8\r\n" +
+            $"Content-Length: {bytes.Length}\r\n" +
+            "Connection: close\r\n\r\n";
+        var headerBytes = Encoding.ASCII.GetBytes(header);
+        await stream.WriteAsync(headerBytes, ct).ConfigureAwait(false);
+        await stream.WriteAsync(bytes, ct).ConfigureAwait(false);
+        await stream.FlushAsync(ct).ConfigureAwait(false);
+    }
+}

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -311,24 +311,212 @@ public sealed class NineRouterApiClientTests
         Assert.Equal("abc.def", token);
     }
 
+    [Fact]
+    public async Task StartOAuthAsync_Authorize_ReturnsBrowserUrl()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "authUrl": "https://claude.ai/oauth/authorize?code_challenge=abc",
+              "state": "st-1",
+              "codeVerifier": "verifier-secret",
+              "redirectUri": "http://127.0.0.1:4242/callback",
+              "flowType": "authorization_code_pkce"
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var start = await client.StartOAuthAsync("claude", "http://127.0.0.1:4242/callback");
+
+        Assert.Equal("claude", start.Provider);
+        Assert.Equal("https://claude.ai/oauth/authorize?code_challenge=abc", start.BrowserUrl);
+        Assert.Equal("st-1", start.State);
+        Assert.Equal("verifier-secret", start.CodeVerifier);
+        Assert.Equal("authorization_code_pkce", start.FlowType);
+        Assert.Equal("GET", handler.Requests[0].Method);
+        Assert.Equal("/api/oauth/claude/authorize", handler.Requests[0].Path);
+        Assert.Contains("redirect_uri=", handler.Requests[0].Query, StringComparison.Ordinal);
+        Assert.Contains("127.0.0.1", handler.Requests[0].Query, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task StartOAuthAsync_GitHubDeviceCode_ReturnsVerificationUrl()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "device_code": "dev-code",
+              "user_code": "ABCD-1234",
+              "verification_uri": "https://github.com/login/device",
+              "verification_uri_complete": "https://github.com/login/device?user_code=ABCD-1234",
+              "expires_in": 900,
+              "interval": 5
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var start = await client.StartOAuthAsync("github");
+
+        Assert.Equal("https://github.com/login/device?user_code=ABCD-1234", start.BrowserUrl);
+        Assert.Equal("dev-code", start.DeviceCode);
+        Assert.Equal(5, start.IntervalSeconds);
+        Assert.Equal("/api/oauth/github/device-code", handler.Requests[0].Path);
+    }
+
+    [Fact]
+    public async Task PollOAuthUntilConnectedAsync_PendingThenSuccess_ReturnsConnection()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "success": false, "pending": true, "error": "authorization_pending" }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "success": true, "connection": { "id": "conn-gh", "provider": "github", "authType": "oauth", "name": "octocat" } }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var connected = await client.PollOAuthUntilConnectedAsync(
+            "github",
+            "dev-code",
+            codeVerifier: null,
+            timeout: TimeSpan.FromSeconds(5),
+            pollInterval: TimeSpan.Zero);
+
+        Assert.Equal("conn-gh", connected.Id);
+        Assert.Equal("github", connected.Provider);
+        Assert.Equal(2, handler.Requests.Count);
+        Assert.Equal("POST", handler.Requests[0].Method);
+        Assert.Equal("/api/oauth/github/poll", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("dev-code", body.RootElement.GetProperty("deviceCode").GetString());
+    }
+
+    [Fact]
+    public async Task StartOAuthAsync_401ThenLoginCookieThenRetry_Succeeds()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.Unauthorized, """{ "error": "Unauthorized" }""");
+        handler.EnqueueJson(
+            HttpStatusCode.OK,
+            """{ "success": true }""",
+            setCookie: "auth_token=jwt-oauth; HttpOnly; Path=/; SameSite=Lax");
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "authUrl": "https://accounts.google.com/o/oauth2/v2/auth?client_id=x", "state": "st", "codeVerifier": "cv" }
+            """);
+        using var client = new ApiClient(Port, handler, dashboardPassword: "secret-password");
+
+        var start = await client.StartOAuthAsync("gemini-cli", "http://127.0.0.1:9/callback");
+
+        Assert.Contains("accounts.google.com", start.BrowserUrl, StringComparison.Ordinal);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal("/api/oauth/gemini-cli/authorize", handler.Requests[0].Path);
+        Assert.Equal("/api/auth/login", handler.Requests[1].Path);
+        Assert.Equal("/api/oauth/gemini-cli/authorize", handler.Requests[2].Path);
+        Assert.Equal("auth_token=jwt-oauth", handler.Requests[2].Cookie);
+    }
+
+    [Fact]
+    public async Task PollOAuthUntilConnectedAsync_TimeoutWhilePending_ThrowsNineRouterApiException()
+    {
+        using var handler = new FakeApiHandler();
+        handler.SetDefaultJson(HttpStatusCode.OK, """{ "success": false, "pending": true, "error": "authorization_pending" }""");
+        using var client = new ApiClient(Port, handler);
+
+        var ex = await Assert.ThrowsAsync<NineRouterApiException>(() =>
+            client.PollOAuthUntilConnectedAsync(
+                "github",
+                "dev-code",
+                codeVerifier: null,
+                timeout: TimeSpan.FromMilliseconds(30),
+                pollInterval: TimeSpan.FromMilliseconds(10)));
+
+        Assert.Equal(HttpStatusCode.RequestTimeout, ex.StatusCode);
+        Assert.Contains("timed out", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("dev-code", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task PollOAuthAsync_AccessDenied_NotPending()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "success": false, "pending": false, "error": "access_denied", "errorDescription": "User denied access" }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var result = await client.PollOAuthAsync("github", "dev-code");
+
+        Assert.False(result.Success);
+        Assert.False(result.Pending);
+        Assert.Equal("User denied access", result.Error);
+    }
+
+    [Fact]
+    public async Task ExchangeOAuthAsync_PostsCode_ReturnsConnection()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "success": true, "connection": { "id": "conn-claude", "provider": "claude", "authType": "oauth" } }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var connected = await client.ExchangeOAuthAsync(
+            "claude",
+            "auth-code",
+            "http://127.0.0.1:4242/callback",
+            "verifier-secret",
+            "st-1");
+
+        Assert.Equal("conn-claude", connected.Id);
+        Assert.Equal("/api/oauth/claude/exchange", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("auth-code", body.RootElement.GetProperty("code").GetString());
+        Assert.Equal("http://127.0.0.1:4242/callback", body.RootElement.GetProperty("redirectUri").GetString());
+        Assert.Equal("verifier-secret", body.RootElement.GetProperty("codeVerifier").GetString());
+    }
+
+    [Fact]
+    public async Task OAuthCallbackListener_ReceivesCode_ReturnsCode()
+    {
+        using var listener = OAuthCallbackListener.Start();
+        var hit = Task.Run(async () =>
+        {
+            using var http = new HttpClient();
+            await http.GetAsync(listener.RedirectUri + "?code=loopback-code&state=st");
+        });
+
+        var code = await listener.WaitForCodeAsync(TimeSpan.FromSeconds(5));
+        await hit;
+
+        Assert.Equal("loopback-code", code);
+    }
+
     private sealed class FakeApiHandler : HttpMessageHandler
     {
         private readonly Queue<Func<HttpResponseMessage>> _responses = new();
+        private Func<HttpResponseMessage>? _default;
 
         public List<CapturedRequest> Requests { get; } = [];
 
         public void EnqueueJson(HttpStatusCode status, string json, string? setCookie = null)
         {
-            _responses.Enqueue(() =>
+            _responses.Enqueue(() => CreateJson(status, json, setCookie));
+        }
+
+        public void SetDefaultJson(HttpStatusCode status, string json)
+        {
+            _default = () => CreateJson(status, json);
+        }
+
+        private static HttpResponseMessage CreateJson(HttpStatusCode status, string json, string? setCookie = null)
+        {
+            var response = new HttpResponseMessage(status)
             {
-                var response = new HttpResponseMessage(status)
-                {
-                    Content = new StringContent(json, Encoding.UTF8, "application/json")
-                };
-                if (setCookie is not null)
-                    response.Headers.TryAddWithoutValidation("Set-Cookie", setCookie);
-                return response;
-            });
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            };
+            if (setCookie is not null)
+                response.Headers.TryAddWithoutValidation("Set-Cookie", setCookie);
+            return response;
         }
 
         protected override async Task<HttpResponseMessage> SendAsync(
@@ -343,20 +531,32 @@ public sealed class NineRouterApiClientTests
             var path = uri.IsAbsoluteUri ? uri.AbsolutePath : uri.OriginalString;
             if (!path.StartsWith('/'))
                 path = "/" + path.TrimStart('/');
+            var query = uri.IsAbsoluteUri ? uri.Query : null;
+            if (query is { Length: > 0 } && path.Contains('?', StringComparison.Ordinal))
+            {
+                var q = path.IndexOf('?', StringComparison.Ordinal);
+                query = path[q..];
+                path = path[..q];
+            }
 
             request.Headers.TryGetValues("Cookie", out var cookies);
             Requests.Add(new CapturedRequest(
                 request.Method.Method,
                 path,
                 string.IsNullOrEmpty(body) ? null : body,
-                cookies?.FirstOrDefault()));
+                cookies?.FirstOrDefault(),
+                string.IsNullOrEmpty(query) ? null : query));
 
             if (_responses.Count == 0)
-                throw new InvalidOperationException($"Unexpected {request.Method} {path}");
+            {
+                if (_default is null)
+                    throw new InvalidOperationException($"Unexpected {request.Method} {path}");
+                return _default();
+            }
 
             return _responses.Dequeue()();
         }
     }
 
-    private sealed record CapturedRequest(string Method, string Path, string? Body, string? Cookie);
+    private sealed record CapturedRequest(string Method, string Path, string? Body, string? Cookie, string? Query = null);
 }


### PR DESCRIPTION
Start the engine OAuth flow from Providers and wait until the connection is stored.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>