### PR TITLE
feat: wire 9Router models into agent configs and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **9Router managed engine** (`EngineCatalog`, `NineRouter/*`, `AgentConfigurationService`, `README.md`): install 9Router from npm (Node.js 18+), start and stop it alongside CLIProxyAPI and Perplexity, manage Providers connections, sign in Claude / Gemini / Copilot over OAuth, and point coding agents at `http://127.0.0.1:20128/v1` with `TUNNEL_AGENT_9ROUTER_API_KEY`.
+
 ### Fixed
 
 - **Cursor quota showed the old single spend bar** (`CursorQuotaParser`, `QuotaFetchService`): Cursor Settings now reports **Auto + Composer** and **API** as separate percent buckets (`autoPercentUsed` / `apiPercentUsed`). Quota uses those bars instead of `includedSpend/limit`, keeps on-demand spend when present, and falls back to `/auth/usage` or usage-summary when `planUsage` is missing (Team/Enterprise). Token refresh retries both dashboard calls; parse/network failures surface as a quota error instead of an empty "not loaded" state.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Tunnel Agent</h1>
 
 <p align="center">
-  Desktop UI for <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI</a> and <a href="https://github.com/henrique-coder/perplexity-webui-scraper">Perplexity WebUI Scraper</a>. Manage OAuth providers, API keys, and Perplexity session accounts, then point any coding agent at the local endpoint.<br><br>One click to connect. Works with whatever you already have.
+  Desktop UI for <a href="https://github.com/router-for-me/CLIProxyAPI">CLIProxyAPI</a>, <a href="https://github.com/henrique-coder/perplexity-webui-scraper">Perplexity WebUI Scraper</a>, and <a href="https://github.com/decolua/9router">9Router</a>. Manage OAuth providers, API keys, and Perplexity session accounts, then point any coding agent at the local endpoint.<br><br>One click to connect. Works with whatever you already have.
 </p>
 
 <p align="center">
@@ -41,7 +41,7 @@
 
 - 🖥️ **Native Windows Experience**: clean Avalonia UI that respects your system theme and keeps local engine management in one place
 - 🌍 **Multi-Language UI (i18n)**: fully localized interface with runtime language switching across 14 languages, auto-detecting your system language on first launch
-- 🔀 **Multi-Engine Control**: run and manage both CLIProxyAPI and Perplexity from the same desktop app, with per-engine configuration, endpoint controls, and status
+- 🔀 **Multi-Engine Control**: run and manage CLIProxyAPI, Perplexity, and 9Router from the same desktop app, with per-engine configuration, endpoint controls, and status
 - 🚀 **One-Click Server Management**: start and stop each local engine directly from the Providers view
 - 🔐 **Credential Storage**: secure handling for OAuth tokens, custom provider API keys, and file-based Perplexity session accounts stored under Tunnel Agent settings
 - 👥 **Provider Management**: connect Claude Code, OpenAI Codex, Gemini CLI, Kimi, Antigravity, xAI (Grok), and custom OpenAI-compatible providers
@@ -93,6 +93,15 @@ Tunnel Agent now includes first-class support for the Perplexity WebUI Scraper e
 - edit account labels in-place from the account list
 - view Perplexity endpoint status and available models from the Perplexity server
 - keep Perplexity on a selected release instead of being forced to latest
+
+### [9Router](https://github.com/decolua/9router)
+
+9Router is a third OpenAI-compatible local engine. Tunnel Agent installs it from the npm registry (a tarball, not GitHub release binaries) and requires **Node.js 18+** on the machine. You can:
+
+- install, start, and stop 9Router from the same UI
+- add API-key provider connections and OAuth for Claude, Gemini, and GitHub Copilot
+- point coding agents at `http://127.0.0.1:20128/v1` using `TUNNEL_AGENT_9ROUTER_API_KEY`
+- open 9Router’s own dashboard for combos, routing, and other advanced features the desktop app does not replicate
 
 ## Supported Ecosystem
 
@@ -170,13 +179,13 @@ scoop bucket add villoh https://github.com/Villoh/scoop-bucket
 scoop install tunnel-agent
 ```
 
-**Requirements:** Windows 10 or later.
+**Requirements:** Windows 10 or later. 9Router also needs [Node.js 18+](https://nodejs.org/) on PATH.
 
 ## Usage
 
 1. **Start the engine**: click the play button next to the endpoint. The status indicator turns green when the engine is running.
 2. **Connect providers**: open the Providers tab for CLIProxyAPI, connect OAuth providers (Claude, Gemini CLI, Kimi…) or add custom API key accounts.
-3. **Configure your agents**: open the Agents tab to auto-write or manually copy the proxy config for each agent. For unsupported clients, copy the endpoint (e.g. `http://127.0.0.1:8317/v1`) from the Providers header and configure it manually.
+3. **Configure your agents**: open the Agents tab to auto-write or manually copy the proxy config for each agent. For unsupported clients, copy the endpoint from the Providers header (`http://127.0.0.1:8317/v1` for CLIProxyAPI, `http://127.0.0.1:8327/v1` for Perplexity, `http://127.0.0.1:20128/v1` for 9Router) and configure it manually.
 4. **Track quota**: open the Quota tab to see remaining quota for connected CLIProxyAPI providers and standalone IDE accounts (Kiro, Trae).
 
 ## Development
@@ -199,6 +208,7 @@ dotnet run --project src/TunnelAgent.Avalonia/TunnelAgent.Avalonia.csproj
 - [VibeProxy](https://github.com/automazeio/vibeproxy): original concept and inspiration
 - [CLIProxyAPI](https://github.com/router-for-me/CLIProxyAPI): the unified proxy that powers multi-provider support
 - [perplexity-webui-scraper](https://github.com/henrique-coder/perplexity-webui-scraper): Perplexity engine and session token CLI
+- [9Router](https://github.com/decolua/9router): OpenAI-compatible local router installed from npm
 - [Quotio](https://github.com/nguyenphutrong/quotio): reference implementation for quota tracking and IDE account detection
 - [OpenUsage](https://github.com/robinebers/openusage): provider API documentation and reference implementations for Claude, Codex, Kiro, and more quota endpoints
 

--- a/docs/app-data-storage.md
+++ b/docs/app-data-storage.md
@@ -10,6 +10,10 @@ Tunnel Agent writes non-credential app data to the following locations.
 | macOS    | `~/Library/Application Support/TunnelAgent/engine/` |
 | Linux    | `~/.local/share/TunnelAgent/engine/`                |
 
+CLIProxyAPI and Perplexity binaries live in that `engine/` directory under their engine id. 9Router is installed from the npm tarball into `{LocalDataDirectory}/engine/9router/` (Windows `%LocalAppData%\TunnelAgent\engine\9router\`, macOS `~/Library/Application Support/TunnelAgent/engine/9router/`, Linux `~/.local/share/TunnelAgent/engine/9router/`).
+
+9Router’s own runtime data (SQLite, dashboard session, and so on) stays in 9Router’s directories, not under Tunnel Agent: `%APPDATA%\9router` on Windows and `~/.9router` on macOS/Linux.
+
 ## Application settings
 
 | Platform | Path                                              |

--- a/src/TunnelAgent.Avalonia/Services/AgentConfigurationService.cs
+++ b/src/TunnelAgent.Avalonia/Services/AgentConfigurationService.cs
@@ -410,18 +410,22 @@ public sealed class AgentConfigurationService
 
     private const string OpenCodeCliProxyProviderKey   = "tunnel-agent-cliproxy";
     private const string OpenCodePerplexityProviderKey = "tunnel-agent-perplexity";
+    private const string OpenCodeNineRouterProviderKey = "tunnel-agent-9router";
 
     private static JsonObject BuildOpenCodeProvidersBlock(
         IReadOnlyList<ModelEntry> entries,
         Dictionary<string, ModelsDevService.ModelInfo> modelInfoMap)
     {
-        var cliproxy   = entries.Where(m => !IsPerplexityEntry(m)).ToList();
-        var perplexity = entries.Where(IsPerplexityEntry).ToList();
-        var providers  = new JsonObject();
+        var cliproxy    = entries.Where(m => !IsPerplexityEntry(m) && !IsNineRouterEntry(m)).ToList();
+        var perplexity  = entries.Where(IsPerplexityEntry).ToList();
+        var nineRouter  = entries.Where(IsNineRouterEntry).ToList();
+        var providers   = new JsonObject();
         if (cliproxy.Count > 0)
             providers[OpenCodeCliProxyProviderKey]   = BuildOpenCodeProviderBlock(cliproxy, modelInfoMap);
         if (perplexity.Count > 0)
             providers[OpenCodePerplexityProviderKey] = BuildOpenCodeProviderBlock(perplexity, modelInfoMap);
+        if (nineRouter.Count > 0)
+            providers[OpenCodeNineRouterProviderKey] = BuildOpenCodeProviderBlock(nineRouter, modelInfoMap);
         return providers;
     }
 
@@ -486,6 +490,7 @@ public sealed class AgentConfigurationService
         {
             providers.Remove(OpenCodeCliProxyProviderKey);
             providers.Remove(OpenCodePerplexityProviderKey);
+            providers.Remove(OpenCodeNineRouterProviderKey);
             if (providers.Count == 0) root.Remove("provider");
         }
         else if (modelEntries is { Count: > 0 })
@@ -537,9 +542,15 @@ public sealed class AgentConfigurationService
     private const string PiCliProxyProviderKey = CliProxyProviderKey;
     private const string PiCliProxyAnthropicProviderKey = CliProxyAnthropicProviderKey;
     private const string PiPerplexityProviderKey = "tunnel-agent-perplexity";
+    private const string PiNineRouterProviderKey = "tunnel-agent-9router";
 
     private static bool IsPerplexityEntry(ModelEntry m) =>
-        !string.IsNullOrEmpty(m.EngineBaseUrl) && m.EngineBaseUrl.Contains(":8327", StringComparison.Ordinal);
+        string.Equals(m.ApiKey, PerplexityAccountCatalogService.EnvVarName, StringComparison.Ordinal) ||
+        (!string.IsNullOrEmpty(m.EngineBaseUrl) && m.EngineBaseUrl.Contains(":8327", StringComparison.Ordinal));
+
+    private static bool IsNineRouterEntry(ModelEntry m) =>
+        string.Equals(m.ApiKey, NineRouterClientKeyService.EnvVarName, StringComparison.Ordinal) ||
+        (!string.IsNullOrEmpty(m.EngineBaseUrl) && m.EngineBaseUrl.Contains(":20128", StringComparison.Ordinal));
 
     private static bool IsAnthropicEntry(ModelEntry m) =>
         !string.IsNullOrEmpty(m.OwnedBy) && m.OwnedBy.Equals("anthropic", StringComparison.OrdinalIgnoreCase);
@@ -560,9 +571,10 @@ public sealed class AgentConfigurationService
         IReadOnlyList<ModelEntry> entries,
         Dictionary<string, ModelsDevService.ModelInfo> modelInfoMap)
     {
-        var cliproxy   = entries.Where(m => !IsAnthropicEntry(m) && !IsPerplexityEntry(m)).ToList();
-        var cliproxyAnthropic = entries.Where(IsAnthropicEntry).ToList();
+        var cliproxy   = entries.Where(m => !IsAnthropicEntry(m) && !IsPerplexityEntry(m) && !IsNineRouterEntry(m)).ToList();
+        var cliproxyAnthropic = entries.Where(m => IsAnthropicEntry(m) && !IsPerplexityEntry(m) && !IsNineRouterEntry(m)).ToList();
         var perplexity = entries.Where(IsPerplexityEntry).ToList();
+        var nineRouter = entries.Where(IsNineRouterEntry).ToList();
         var providers  = new JsonObject();
         if (cliproxy.Count > 0)
             providers[PiCliProxyProviderKey]   = BuildPiProviderBlock(cliproxy, modelInfoMap, "openai-completions");
@@ -570,6 +582,8 @@ public sealed class AgentConfigurationService
             providers[PiCliProxyAnthropicProviderKey] = BuildPiProviderBlock(cliproxyAnthropic, modelInfoMap, "anthropic-messages");
         if (perplexity.Count > 0)
             providers[PiPerplexityProviderKey] = BuildPiProviderBlock(perplexity, modelInfoMap);
+        if (nineRouter.Count > 0)
+            providers[PiNineRouterProviderKey] = BuildPiProviderBlock(nineRouter, modelInfoMap);
         return providers;
     }
 
@@ -662,16 +676,20 @@ public sealed class AgentConfigurationService
 
         providers.Children.Remove(new YamlScalarNode(CliProxyProviderKey));
         providers.Children.Remove(new YamlScalarNode(CliProxyAnthropicProviderKey));
+        providers.Children.Remove(new YamlScalarNode(PiNineRouterProviderKey));
 
         if (!remove)
         {
             var metadata = modelInfoMap ?? new Dictionary<string, ModelsDevService.ModelInfo>(StringComparer.OrdinalIgnoreCase);
-            var openAi = entries.Where(m => !IsAnthropicEntry(m) && !IsPerplexityEntry(m)).ToList();
-            var anthropic = entries.Where(IsAnthropicEntry).ToList();
+            var openAi = entries.Where(m => !IsAnthropicEntry(m) && !IsPerplexityEntry(m) && !IsNineRouterEntry(m)).ToList();
+            var anthropic = entries.Where(m => IsAnthropicEntry(m) && !IsPerplexityEntry(m) && !IsNineRouterEntry(m)).ToList();
+            var nineRouter = entries.Where(IsNineRouterEntry).ToList();
             if (openAi.Count > 0)
                 providers.Add(CliProxyProviderKey, BuildOmpProviderBlock(openAi, metadata, "openai-completions"));
             if (anthropic.Count > 0)
                 providers.Add(CliProxyAnthropicProviderKey, BuildOmpProviderBlock(anthropic, metadata, "anthropic-messages"));
+            if (nineRouter.Count > 0)
+                providers.Add(PiNineRouterProviderKey, BuildOmpProviderBlock(nineRouter, metadata, "openai-completions"));
         }
 
         if (providers.Children.Count == 0)
@@ -800,6 +818,7 @@ public sealed class AgentConfigurationService
             providers.Remove(PiCliProxyProviderKey);
             providers.Remove(PiCliProxyAnthropicProviderKey);
             providers.Remove(PiPerplexityProviderKey);
+            providers.Remove(PiNineRouterProviderKey);
         }
         else if (modelEntries is { Count: > 0 })
         {
@@ -1190,7 +1209,7 @@ public sealed class AgentConfigurationService
             uri.Host is not ("127.0.0.1" or "localhost"))
             return false;
 
-        return uri.Port is 8317 or 8327 || managedPorts?.Contains(uri.Port) == true;
+        return uri.Port is 8317 or 8327 or 20128 || managedPorts?.Contains(uri.Port) == true;
     }
 
     private static string? ExtractGrokModelId(string header)

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -410,6 +410,7 @@ SelectedSection is SectionKey.Logs;
             OnPropertyChanged(nameof(TotalAvailableModelCount));
             OnPropertyChanged(nameof(HasCliProxySelectableModels));
             OnPropertyChanged(nameof(HasPerplexitySelectableModels));
+            OnPropertyChanged(nameof(HasNineRouterSelectableModels));
             RefreshFallbackModelOptions();
         }
         CliProxyModelGroups.CollectionChanged += OnEngineModelsChanged;
@@ -3278,7 +3279,7 @@ SelectedSection is SectionKey.Logs;
             {
                 var def = FindDef(target.Id);
                 var r = IsAgentConfigDefaultMode
-                    ? await Task.Run(() => _agentConfiguration.Revert(def, new[] { CliProxyPort, PerplexityPort })).ConfigureAwait(false)
+                    ? await Task.Run(() => _agentConfiguration.Revert(def, new[] { CliProxyPort, PerplexityPort, NineRouterPort })).ConfigureAwait(false)
                     : await _agentConfiguration.ApplyAsync(def, AgentProxyBaseUrl, CurrentAgentApiKey, models, modelEntries).ConfigureAwait(false);
                 var displayPath = r.ConfigPath;
                 if (r.RawPreviews.Count > 0)
@@ -3330,21 +3331,25 @@ SelectedSection is SectionKey.Logs;
         foreach (var m in selected)
         {
             var isPerplexity = string.Equals(m.EngineId, EngineCatalog.PerplexityWebUiScraper.Id, StringComparison.OrdinalIgnoreCase);
-            var engineBaseUrl = isPerplexity ? PerplexityEndpointUrl + "/v1" : CliProxyEndpointUrl + "/v1";
-            var apiKey = isPerplexity
-                ? TunnelAgent.Services.PerplexityAccountCatalogService.EnvVarName
+            var isNineRouter = string.Equals(m.EngineId, EngineCatalog.NineRouter.Id, StringComparison.OrdinalIgnoreCase);
+            var engineBaseUrl = isNineRouter ? NineRouterEndpointUrl + "/v1"
+                : isPerplexity ? PerplexityEndpointUrl + "/v1"
+                : CliProxyEndpointUrl + "/v1";
+            var apiKey = isNineRouter ? NineRouterClientKeyService.EnvVarName
+                : isPerplexity ? PerplexityAccountCatalogService.EnvVarName
                 : "TUNNEL_AGENT_CLIPROXY_API_KEY";
-            var displayName = await ResolveDisplayNameAsync(m.Name, isPerplexity);
+            var displayName = await ResolveDisplayNameAsync(m.Name, isPerplexity, isNineRouter);
             entries.Add(new TunnelAgent.Services.ModelEntry(m.Name, m.Provider, engineBaseUrl, apiKey, displayName));
         }
         return entries;
     }
 
-    private static async Task<string> ResolveDisplayNameAsync(string modelId, bool isPerplexity)
+    private static async Task<string> ResolveDisplayNameAsync(string modelId, bool isPerplexity, bool isNineRouter)
     {
         var info = await TunnelAgent.Services.ModelsDevService.Instance
             .GetModelInfoAsync(modelId).ConfigureAwait(false);
         var name = info?.Name is string n ? StripProviderPrefix(n) : FormatModelId(modelId);
+        if (isNineRouter) return $"{name} (Tunnel Agent - 9Router)";
         return isPerplexity ? $"{name} (Tunnel Agent - Perplexity)" : $"{name} (Tunnel Agent)";
     }
 
@@ -3373,8 +3378,10 @@ SelectedSection is SectionKey.Logs;
 
     public IEnumerable<SelectableModelViewModel> CliProxySelectableModels  => SelectableModels.Where(m => m.EngineId == EngineCatalog.CliProxyApi.Id);
     public IEnumerable<SelectableModelViewModel> PerplexitySelectableModels => SelectableModels.Where(m => m.EngineId == EngineCatalog.PerplexityWebUiScraper.Id);
+    public IEnumerable<SelectableModelViewModel> NineRouterSelectableModels => SelectableModels.Where(m => m.EngineId == EngineCatalog.NineRouter.Id);
     public bool HasCliProxySelectableModels  => CliProxySelectableModels.Any();
     public bool HasPerplexitySelectableModels => PerplexitySelectableModels.Any();
+    public bool HasNineRouterSelectableModels => NineRouterSelectableModels.Any();
 
     private void PopulateSelectableModels()
     {
@@ -3393,12 +3400,21 @@ SelectedSection is SectionKey.Logs;
                 vm.PropertyChanged += OnSelectableModelPropertyChanged;
                 SelectableModels.Add(vm);
             }
+        foreach (var group in NineRouterModelGroups)
+            foreach (var model in group.Models)
+            {
+                var vm = new SelectableModelViewModel(model.Name, group.ProviderName, EngineCatalog.NineRouter.Id);
+                vm.PropertyChanged += OnSelectableModelPropertyChanged;
+                SelectableModels.Add(vm);
+            }
         ApplyModelFilter();
         OnPropertyChanged(nameof(HasSelectableModels));
         OnPropertyChanged(nameof(HasCliProxySelectableModels));
         OnPropertyChanged(nameof(HasPerplexitySelectableModels));
+        OnPropertyChanged(nameof(HasNineRouterSelectableModels));
         OnPropertyChanged(nameof(CliProxySelectableModels));
         OnPropertyChanged(nameof(PerplexitySelectableModels));
+        OnPropertyChanged(nameof(NineRouterSelectableModels));
         OnPropertyChanged(nameof(ModelsExpanderLabel));
         OnPropertyChanged(nameof(AllVisibleModelsSelected));
         if (IsAgentConfigManualMode && ShowAgentConfigDialog && !AgentConfigHasResult)

--- a/src/TunnelAgent.Avalonia/Views/AgentConfigOverlayView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/AgentConfigOverlayView.axaml
@@ -262,6 +262,29 @@
                                         </ItemsControl.ItemTemplate>
                                     </ItemsControl>
                                 </StackPanel>
+                                <!-- 9Router models -->
+                                <StackPanel IsVisible="{Binding HasNineRouterSelectableModels}" Spacing="4">
+                                    <TextBlock Classes="section-label" Text="9ROUTER" Margin="2,4,2,2" />
+                                    <ItemsControl ItemsSource="{Binding NineRouterSelectableModels}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate x:DataType="vm:SelectableModelViewModel">
+                                                <Grid ColumnDefinitions="Auto,*,Auto" Margin="2,3"
+                                                      IsVisible="{Binding IsVisible}">
+                                                    <CheckBox Grid.Column="0"
+                                                              IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                                              VerticalAlignment="Center" />
+                                                    <TextBlock Grid.Column="1" Text="{Binding Name}"
+                                                               FontSize="12" VerticalAlignment="Center"
+                                                               TextTrimming="CharacterEllipsis" />
+                                                    <TextBlock Grid.Column="2" Text="{Binding Provider}"
+                                                               FontSize="10" VerticalAlignment="Center"
+                                                               Foreground="{DynamicResource FgFaintBrush}"
+                                                               Margin="8,0,0,0" />
+                                                </Grid>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
                             </StackPanel>
                         </StackPanel>
 

--- a/tests/TunnelAgent.Tests/AgentConfigurationServiceTests.cs
+++ b/tests/TunnelAgent.Tests/AgentConfigurationServiceTests.cs
@@ -1,11 +1,26 @@
 using System.Linq;
+using TunnelAgent.Infrastructure.Services;
 using TunnelAgent.Services;
 
 namespace TunnelAgent.Tests;
 
-public sealed class AgentConfigurationServiceTests
+[Collection("UserEnvironment")]
+public sealed class AgentConfigurationServiceTests : IDisposable
 {
     private const string Proxy = "http://127.0.0.1:8317/v1";
+    private const string NineRouterProxy = "http://127.0.0.1:20128/v1";
+
+    private readonly InMemoryUserEnvironmentService _env = new();
+    private readonly IUserEnvironmentService _previousEnv;
+
+    public AgentConfigurationServiceTests()
+    {
+        _previousEnv = UserEnvironmentService.SetImplementation(_env);
+        _env.Set(NineRouterClientKeyService.EnvVarName, "9router-key");
+    }
+
+    public void Dispose() =>
+        UserEnvironmentService.SetImplementation(_previousEnv);
 
     private static ModelEntry Model(string id, string display) =>
         new(id, "", Proxy, "", display);
@@ -363,6 +378,75 @@ providers:
         Assert.Equal("{}", content);
     }
 
+    [Fact]
+    public async System.Threading.Tasks.Task PreviewAsync_OpenCode_WritesNineRouterProviderAndEnvVar()
+    {
+        var agent = Assert.Single(AgentCatalog.All, a => a.Id == "opencode");
+        var service = new AgentConfigurationService();
+        var entries = new[]
+        {
+            new ModelEntry(
+                "gpt-4o",
+                "openai",
+                NineRouterProxy,
+                NineRouterClientKeyService.EnvVarName,
+                "GPT-4o (Tunnel Agent - 9Router)")
+        };
+
+        var preview = Assert.Single(await service.PreviewAsync(agent, Proxy, "", modelEntries: entries));
+
+        Assert.Equal("opencode.json", preview.Filename);
+        Assert.Contains("\"tunnel-agent-9router\"", preview.Content);
+        Assert.Contains("\"baseURL\": \"http://127.0.0.1:20128/v1\"", preview.Content);
+        Assert.Contains($"\"apiKey\": \"{{env:{NineRouterClientKeyService.EnvVarName}}}\"", preview.Content);
+        Assert.DoesNotContain("tunnel-agent-cliproxy", preview.Content);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task PreviewAsync_Pi_WritesNineRouterProviderAndEnvVar()
+    {
+        var agent = Assert.Single(AgentCatalog.All, a => a.Id == "pi");
+        var service = new AgentConfigurationService();
+        var entries = new[]
+        {
+            new ModelEntry(
+                "claude-sonnet-4",
+                "anthropic",
+                NineRouterProxy,
+                NineRouterClientKeyService.EnvVarName,
+                "Claude Sonnet 4 (Tunnel Agent - 9Router)")
+        };
+
+        var preview = Assert.Single(await service.PreviewAsync(agent, Proxy, "", modelEntries: entries));
+
+        Assert.Equal("models.json", preview.Filename);
+        Assert.Contains("\"tunnel-agent-9router\"", preview.Content);
+        Assert.Contains("\"baseUrl\": \"http://127.0.0.1:20128/v1\"", preview.Content);
+        Assert.Contains($"\"apiKey\": \"${{{NineRouterClientKeyService.EnvVarName}}}\"", preview.Content);
+        Assert.DoesNotContain("tunnel-agent-cliproxy-anthropic", preview.Content);
+    }
+
+    [Fact]
+    public void MergeOmpModelsYaml_NineRouterModels_WritesNineRouterProvider()
+    {
+        var entries = new[]
+        {
+            new ModelEntry(
+                "gpt-4o",
+                "openai",
+                NineRouterProxy,
+                NineRouterClientKeyService.EnvVarName,
+                "GPT-4o (Tunnel Agent - 9Router)")
+        };
+
+        var content = AgentConfigurationService.MergeOmpModelsYaml("", entries, modelInfoMap: null, remove: false);
+
+        Assert.Contains("tunnel-agent-9router:", content);
+        Assert.Contains("baseUrl: http://127.0.0.1:20128/v1", content);
+        Assert.Contains(NineRouterClientKeyService.EnvVarName, content);
+        Assert.DoesNotContain("tunnel-agent-cliproxy:", content);
+    }
+
     [Theory]
     [InlineData("providers: [")]
     [InlineData("- item")]
@@ -378,5 +462,13 @@ providers:
         int count = 0, i = 0;
         while ((i = haystack.IndexOf(needle, i, System.StringComparison.Ordinal)) >= 0) { count++; i += needle.Length; }
         return count;
+    }
+
+    private sealed class InMemoryUserEnvironmentService : IUserEnvironmentService
+    {
+        private readonly Dictionary<string, string> _values = new(StringComparer.Ordinal);
+        public string? Get(string name) => _values.TryGetValue(name, out var v) ? v : null;
+        public void Set(string name, string value) => _values[name] = value;
+        public void Remove(string name) => _values.Remove(name);
     }
 }


### PR DESCRIPTION
Point coding agents at the 9Router endpoint with TUNNEL_AGENT_9ROUTER_API_KEY and document the third engine.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>