### PR TITLE
feat(ui): animate sliding tab content

### DIFF
--- a/src/TunnelAgent.Avalonia/Converters/Converters.cs
+++ b/src/TunnelAgent.Avalonia/Converters/Converters.cs
@@ -112,6 +112,14 @@ public sealed class SectionEqualsConverter : IValueConverter
     public object ConvertBack(object? v, Type t, object? p, CultureInfo c) => throw new NotImplementedException();
 }
 
+public sealed class StringEqualsConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is string text && parameter is string expected &&
+        string.Equals(text, expected, StringComparison.OrdinalIgnoreCase);
+    public object ConvertBack(object? v, Type t, object? p, CultureInfo c) => throw new NotImplementedException();
+}
+
 public sealed class SidebarWidthConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml
@@ -30,8 +30,25 @@
                     </ctrl:SlidingTabBar.Tabs>
                 </ctrl:SlidingTabBar>
 
+                <TransitioningContentControl Content="{Binding SelectedSection}"
+                                             HorizontalContentAlignment="Stretch">
+                    <TransitioningContentControl.PageTransition>
+                        <CompositePageTransition>
+                            <CompositePageTransition.PageTransitions>
+                                <PageSlide Duration="0:0:0.22" Orientation="Horizontal"
+                                           SlideInEasing="CubicEaseInOut" SlideOutEasing="CubicEaseInOut" />
+                                <CrossFade Duration="0:0:0.22" />
+                            </CompositePageTransition.PageTransitions>
+                        </CompositePageTransition>
+                    </TransitioningContentControl.PageTransition>
+                    <TransitioningContentControl.ContentTemplate>
+                        <DataTemplate>
+                            <StackPanel x:Name="ConfigTabContent" Tag="{Binding}" Spacing="0">
+                                <StackPanel DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            Spacing="0">
+
                 <!-- ══ GENERAL ══════════════════════════════════════════ -->
-                <StackPanel IsVisible="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=ConfigGeneral}">
+                <StackPanel IsVisible="{Binding Tag, ElementName=ConfigTabContent, Converter={StaticResource SectionEq}, ConverterParameter=ConfigGeneral}">
                     <StackPanel Margin="0,0,0,14">
                         <TextBlock Classes="page-title" Text="{l:Loc ConfigView_General_Title}" />
                         <TextBlock Classes="page-sub" Text="{l:Loc ConfigView_General_Subtitle}" />
@@ -134,7 +151,7 @@
                 </StackPanel>
 
                 <!-- ══ CLIPROXY ══════════════════════════════════════════ -->
-                <StackPanel IsVisible="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=ConfigCliProxy}">
+                <StackPanel IsVisible="{Binding Tag, ElementName=ConfigTabContent, Converter={StaticResource SectionEq}, ConverterParameter=ConfigCliProxy}">
                     <StackPanel Margin="0,0,0,14">
                         <TextBlock Classes="page-title" Text="{l:Loc ConfigView_CLIProxy_Title}" />
                         <TextBlock Classes="page-sub" Text="{l:Loc ConfigView_CLIProxy_Subtitle}" />
@@ -435,7 +452,7 @@
                 </StackPanel>
 
                 <!-- ══ PERPLEXITY ══════════════════════════════════════════ -->
-                <StackPanel IsVisible="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=ConfigPerplexity}">
+                <StackPanel IsVisible="{Binding Tag, ElementName=ConfigTabContent, Converter={StaticResource SectionEq}, ConverterParameter=ConfigPerplexity}">
                     <StackPanel Margin="0,0,0,14">
                         <TextBlock Classes="page-title" Text="{l:Loc ConfigView_Perplexity_Title}" />
                         <TextBlock Classes="page-sub" Text="{l:Loc ConfigView_Perplexity_Subtitle}" />
@@ -605,7 +622,7 @@
                 </StackPanel>
 
                 <!-- ══ 9ROUTER ══════════════════════════════════════════ -->
-                <StackPanel IsVisible="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=ConfigNineRouter}">
+                <StackPanel IsVisible="{Binding Tag, ElementName=ConfigTabContent, Converter={StaticResource SectionEq}, ConverterParameter=ConfigNineRouter}">
                     <StackPanel Margin="0,0,0,14">
                         <TextBlock Classes="page-title" Text="{l:Loc ConfigView_NineRouter_Title}" />
                         <TextBlock Classes="page-sub" Text="{l:Loc ConfigView_NineRouter_Subtitle}" />
@@ -778,6 +795,11 @@
                         </StackPanel>
                     </Border>
                 </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+                        </DataTemplate>
+                    </TransitioningContentControl.ContentTemplate>
+                </TransitioningContentControl>
 
             </StackPanel>
         </ScrollViewer>

--- a/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -53,11 +54,16 @@ public partial class ConfigurationView : UserControl
                 return;
             }
 
-            if (LocalProxySectionLabel.GetVisualRoot() is null ||
-                LocalProxySectionLabel.Bounds.Height <= 0)
+            var label = this.GetVisualDescendants()
+                .OfType<Control>()
+                .FirstOrDefault(control => control.Name == "LocalProxySectionLabel");
+            var card = this.GetVisualDescendants()
+                .OfType<Control>()
+                .FirstOrDefault(control => control.Name == "LocalProxySectionCard");
+            if (label?.GetVisualRoot() is null || label.Bounds.Height <= 0 || card is null)
                 return;
 
-            LocalProxySectionCard.BringIntoView();
+            card.BringIntoView();
             _scrollTimer?.Stop();
         };
         _scrollTimer.Start();

--- a/src/TunnelAgent.Avalonia/Views/LogsView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/LogsView.axaml
@@ -128,11 +128,28 @@
             </ctrl:SlidingTabBar.Tabs>
         </ctrl:SlidingTabBar>
 
+        <TransitioningContentControl Content="{Binding Logs.IsRequestsTab}"
+                                     HorizontalContentAlignment="Stretch">
+            <TransitioningContentControl.PageTransition>
+                <CompositePageTransition>
+                    <CompositePageTransition.PageTransitions>
+                        <PageSlide Duration="0:0:0.22" Orientation="Horizontal"
+                                   SlideInEasing="CubicEaseInOut" SlideOutEasing="CubicEaseInOut" />
+                        <CrossFade Duration="0:0:0.22" />
+                    </CompositePageTransition.PageTransitions>
+                </CompositePageTransition>
+            </TransitioningContentControl.PageTransition>
+            <TransitioningContentControl.ContentTemplate>
+                <DataTemplate>
+                    <StackPanel x:Name="LogsTabContent" Tag="{Binding}" Spacing="0">
+                        <StackPanel DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                    Spacing="0">
+
         <!-- ══════════════════════════════════════════════
              REQUESTS TAB
              ══════════════════════════════════════════════ -->
         <StackPanel Spacing="0"
-                    IsVisible="{Binding Logs.IsRequestsTab}">
+                    IsVisible="{Binding Tag, ElementName=LogsTabContent}">
 
             <!-- Stats bar + Provider dropdown -->
             <Grid Margin="0,0,0,10" ColumnDefinitions="Auto,Auto,Auto,*,Auto,Auto">
@@ -351,7 +368,7 @@
              PROXY LOGS TAB
              ══════════════════════════════════════════════ -->
         <StackPanel Spacing="0"
-                    IsVisible="{Binding Logs.IsProxyLogsTab}">
+                    IsVisible="{Binding Tag, ElementName=LogsTabContent, Converter={StaticResource InvertBool}}">
 
             <!-- Search bar -->
             <Border Margin="0,0,0,10"
@@ -410,5 +427,10 @@
                 </Panel>
             </Border>
         </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </DataTemplate>
+            </TransitioningContentControl.ContentTemplate>
+        </TransitioningContentControl>
     </StackPanel>
 </UserControl>

--- a/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
@@ -19,6 +19,7 @@
         <cv:StringNotEmptyConverter     x:Key="StringNotEmpty" />
         <cv:InvertBoolConverter         x:Key="InvertBool" />
         <cv:BoolToEnableDisableTextConverter x:Key="BoolToEnableDisableText" />
+        <cv:StringEqualsConverter x:Key="StringEq" />
     </UserControl.Resources>
 
     <Panel>
@@ -34,6 +35,23 @@
                         <ctrl:SlidingTab Header="{l:Loc ProvidersView_TabNineRouter}"  Command="{Binding FocusNineRouterCommand}" />
                     </ctrl:SlidingTabBar.Tabs>
                 </ctrl:SlidingTabBar>
+
+                <TransitioningContentControl Content="{Binding ProvidersEngineId}"
+                                             HorizontalContentAlignment="Stretch">
+                    <TransitioningContentControl.PageTransition>
+                        <CompositePageTransition>
+                            <CompositePageTransition.PageTransitions>
+                                <PageSlide Duration="0:0:0.22" Orientation="Horizontal"
+                                           SlideInEasing="CubicEaseInOut" SlideOutEasing="CubicEaseInOut" />
+                                <CrossFade Duration="0:0:0.22" />
+                            </CompositePageTransition.PageTransitions>
+                        </CompositePageTransition>
+                    </TransitioningContentControl.PageTransition>
+                    <TransitioningContentControl.ContentTemplate>
+                        <DataTemplate>
+                            <StackPanel x:Name="ProviderTabContent" Tag="{Binding}" Spacing="0">
+                                <StackPanel DataContext="{Binding DataContext, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                            Spacing="0">
 
                 <Grid Margin="0,0,0,14">
                     <Grid.ColumnDefinitions>
@@ -106,7 +124,7 @@
                     </Grid>
                 </Border>
 
-                <Border Classes="card" IsVisible="{Binding IsPerplexityEngineSelected}" Margin="0,0,0,12">
+                <Border Classes="card" IsVisible="{Binding Tag, ElementName=ProviderTabContent, Converter={StaticResource StringEq}, ConverterParameter=perplexity-webui-scraper}" Margin="0,0,0,12">
                     <StackPanel Margin="16,14" Spacing="12">
                         <Grid ColumnDefinitions="*,Auto">
                             <StackPanel>
@@ -172,7 +190,7 @@
                     </StackPanel>
                 </Border>
 
-                <Border Classes="card" IsVisible="{Binding IsNineRouterEngineSelected}" Margin="0,0,0,12">
+                <Border Classes="card" IsVisible="{Binding Tag, ElementName=ProviderTabContent, Converter={StaticResource StringEq}, ConverterParameter=9router}" Margin="0,0,0,12">
                     <StackPanel Margin="16,14" Spacing="12">
                         <Grid ColumnDefinitions="*,Auto">
                             <StackPanel>
@@ -255,7 +273,7 @@
                     </StackPanel>
                 </Border>
 
-                <StackPanel IsVisible="{Binding IsCliProxyEngineSelected}">
+                <StackPanel IsVisible="{Binding Tag, ElementName=ProviderTabContent, Converter={StaticResource StringEq}, ConverterParameter=cliproxyapi}">
                     <Border Classes="card">
                       <StackPanel>
                         <ItemsControl ItemsSource="{Binding Providers}">
@@ -538,6 +556,11 @@
 
                     </StackPanel>
                 </Border>
+                                </StackPanel>
+                            </StackPanel>
+                        </DataTemplate>
+                    </TransitioningContentControl.ContentTemplate>
+                </TransitioningContentControl>
             </StackPanel>
         </ScrollViewer>
     </Panel>


### PR DESCRIPTION
## Summary
- animate configuration, provider, and log content when their sliding tab changes
- use the same 220ms horizontal slide and cross-fade transition as sidebar navigation

## Validation
- dotnet build src/TunnelAgent.Avalonia/TunnelAgent.Avalonia.csproj --no-restore -o C:\temp\tunnel-agent-build