### PR TITLE
Add 9Router account renaming

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
@@ -597,6 +597,9 @@
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Eliminar conexión</value>
   </data>
+  <data name="ProvidersView_NineRouterConnection_EditNameTooltip" xml:space="preserve">
+    <value>Editar nombre de conexión</value>
+  </data>
   <data name="ProvidersView_NineRouter_EngineNotRunning" xml:space="preserve">
     <value>Inicia 9Router antes de gestionar las conexiones.</value>
   </data>
@@ -605,6 +608,9 @@
   </data>
   <data name="ProvidersView_NineRouter_LoadFailed" xml:space="preserve">
     <value>No se pudieron cargar las conexiones de 9Router: {0}</value>
+  </data>
+  <data name="Dialog_EditNineRouterConnectionName_Title" xml:space="preserve">
+    <value>Editar nombre de conexión de 9Router</value>
   </data>
   <data name="Dialog_AddNineRouterKey_Title" xml:space="preserve">
     <value>Añadir clave API</value>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -609,6 +609,9 @@
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Delete connection</value>
   </data>
+  <data name="ProvidersView_NineRouterConnection_EditNameTooltip" xml:space="preserve">
+    <value>Edit connection name</value>
+  </data>
   <data name="ProvidersView_NineRouter_EngineNotRunning" xml:space="preserve">
     <value>Start 9Router before managing connections.</value>
   </data>
@@ -617,6 +620,9 @@
   </data>
   <data name="ProvidersView_NineRouter_LoadFailed" xml:space="preserve">
     <value>Could not load 9Router connections: {0}</value>
+  </data>
+  <data name="Dialog_EditNineRouterConnectionName_Title" xml:space="preserve">
+    <value>Edit 9Router connection name</value>
   </data>
   <data name="Dialog_AddNineRouterKey_Title" xml:space="preserve">
     <value>Add API key</value>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -225,6 +225,9 @@ SelectedSection is SectionKey.Logs;
     [ObservableProperty] private string _editPerplexityLabelDraft = "";
     [ObservableProperty] private bool _showResetPerplexityDialog;
     [ObservableProperty] private bool _showNineRouterAddKeyDialog;
+    [ObservableProperty] private bool _showEditNineRouterConnectionNameDialog;
+    [ObservableProperty] private NineRouterConnectionViewModel? _editNineRouterConnectionTarget;
+    [ObservableProperty] private string _editNineRouterConnectionNameDraft = "";
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(SelectedNineRouterSupportsApiKey))]
     [NotifyPropertyChangedFor(nameof(SelectedNineRouterSupportsOAuth))]
@@ -2769,6 +2772,53 @@ SelectedSection is SectionKey.Logs;
                     account.Id,
                     new NineRouterUpdateProviderRequest { IsActive = !provider.IsEnabled });
             }
+            await RefreshNineRouterConnectionsAsync();
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    [RelayCommand]
+    private void EditNineRouterConnectionName(NineRouterConnectionViewModel? connection)
+    {
+        if (connection is null) return;
+        EditNineRouterConnectionTarget = connection;
+        EditNineRouterConnectionNameDraft = connection.Name;
+        ShowEditNineRouterConnectionNameDialog = true;
+    }
+
+    [RelayCommand]
+    private void DismissEditNineRouterConnectionNameDialog()
+    {
+        ShowEditNineRouterConnectionNameDialog = false;
+        EditNineRouterConnectionTarget = null;
+        EditNineRouterConnectionNameDraft = "";
+    }
+
+    [RelayCommand]
+    private async Task ConfirmEditNineRouterConnectionNameAsync()
+    {
+        var connection = EditNineRouterConnectionTarget;
+        var name = EditNineRouterConnectionNameDraft.Trim();
+        if (connection is null || string.IsNullOrWhiteSpace(name) || !IsNineRouterEngineRunning || IsNineRouterBusy) return;
+        if (string.Equals(name, connection.Name, StringComparison.CurrentCulture))
+        {
+            DismissEditNineRouterConnectionNameDialog();
+            return;
+        }
+
+        IsNineRouterBusy = true;
+        try
+        {
+            using var client = new ApiClient(NineRouterEngine.Port);
+            await client.UpdateProviderAsync(connection.Id, new NineRouterUpdateProviderRequest { Name = name });
+            DismissEditNineRouterConnectionNameDialog();
             await RefreshNineRouterConnectionsAsync();
         }
         catch (Exception ex)

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -983,6 +983,34 @@
             </Border>
         </Border>
 
+        <!-- Edit 9Router connection name dialog -->
+        <Border x:Name="NineRouterConnectionNameOverlay" IsVisible="{Binding ShowEditNineRouterConnectionNameDialog}" Background="#88000000"
+                HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ZIndex="50"
+                PointerPressed="OnEditNineRouterConnectionNameOverlayPressed"
+                KeyDown="OnEditNineRouterConnectionNameKeyDown" Focusable="True">
+            <Border Classes="card" Width="480" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="24"
+                    PointerPressed="OnDialogCardPressed">
+                <StackPanel Spacing="14">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Grid.Column="0" Classes="row-label" FontSize="15" Text="{l:Loc Dialog_EditNineRouterConnectionName_Title}" VerticalAlignment="Center" />
+                        <Button Grid.Column="1" Classes="icon" Command="{Binding DismissEditNineRouterConnectionNameDialogCommand}" VerticalAlignment="Center">
+                            <lucide:PackIconLucide Kind="X" Width="14" Height="14" />
+                        </Button>
+                    </Grid>
+                    <StackPanel Spacing="4">
+                        <TextBlock Classes="row-desc" Text="{l:Loc Dialog_AddNineRouterKey_Name}" />
+                        <TextBox x:Name="NineRouterConnectionNameBox" Classes="app"
+                                 Text="{Binding EditNineRouterConnectionNameDraft, Mode=TwoWay}"
+                                 KeyDown="OnEditNineRouterConnectionNameKeyDown" />
+                    </StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="0,6,0,0">
+                        <Button Classes="app" Content="{l:Loc Dialog_AddNineRouterKey_Cancel}" Command="{Binding DismissEditNineRouterConnectionNameDialogCommand}" />
+                        <Button Classes="app primary" Content="{l:Loc Dialog_EditPerplexityLabel_Save}" Command="{Binding ConfirmEditNineRouterConnectionNameCommand}" />
+                    </StackPanel>
+                </StackPanel>
+            </Border>
+        </Border>
+
         <!-- Edit Perplexity account label dialog -->
         <Border IsVisible="{Binding ShowEditPerplexityLabelDialog}" Background="#88000000"
                 HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ZIndex="50"

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
@@ -136,6 +136,8 @@ public partial class MainWindow : Window
             Dispatcher.UIThread.Post(() => PerplexityAccountOverlay.Focus(), DispatcherPriority.Input);
         else if (args.PropertyName == nameof(MainWindowViewModel.ShowNineRouterOAuthCodeDialog) && vm.ShowNineRouterOAuthCodeDialog)
             Dispatcher.UIThread.Post(() => NineRouterOAuthCodeOverlay.Focus(), DispatcherPriority.Input);
+        else if (args.PropertyName == nameof(MainWindowViewModel.ShowEditNineRouterConnectionNameDialog) && vm.ShowEditNineRouterConnectionNameDialog)
+            Dispatcher.UIThread.Post(() => this.FindControl<Border>("NineRouterConnectionNameOverlay")?.Focus(), DispatcherPriority.Input);
         else if (args.PropertyName == nameof(MainWindowViewModel.ShowAgentConfigDialog) && vm.ShowAgentConfigDialog)
             Dispatcher.UIThread.Post(() => EnsureAgentConfigOverlay(vm).FocusOverlay(), DispatcherPriority.Input);
     }
@@ -440,6 +442,26 @@ public partial class MainWindow : Window
             PerplexityTokenFlowInputBox.Text = "";
 
         PerplexityTokenFlowInputBox.Focus();
+    }
+
+    private void OnEditNineRouterConnectionNameKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        if (e.Key == Key.Escape)
+        {
+            e.Handled = true;
+            vm.DismissEditNineRouterConnectionNameDialogCommand.Execute(null);
+        }
+        else if (e.Key == Key.Enter)
+        {
+            e.Handled = true;
+            vm.ConfirmEditNineRouterConnectionNameCommand.Execute(null);
+        }
+    }
+
+    private void OnEditNineRouterConnectionNameOverlayPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel vm) vm.DismissEditNineRouterConnectionNameDialogCommand.Execute(null);
     }
 
     private async void OnEditPerplexityLabelKeyDown(object? sender, KeyEventArgs e)

--- a/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
@@ -294,7 +294,7 @@
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="vm:NineRouterConnectionViewModel">
                                                     <Border Background="#08FFFFFF" Margin="16,8,16,10" CornerRadius="8" Padding="14,12">
-                                                        <Grid ColumnDefinitions="*,Auto,Auto">
+                                                        <Grid ColumnDefinitions="*,Auto,Auto,Auto">
                                                             <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
                                                                 <StackPanel Orientation="Horizontal" Spacing="8">
                                                                     <TextBlock Text="{Binding Name}" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource FgBrush}" />
@@ -310,6 +310,13 @@
                                                                           Command="{Binding #Root.DataContext.ToggleNineRouterConnectionCommand}"
                                                                           CommandParameter="{Binding}" />
                                                             <Button Grid.Column="2" Classes="icon-btn" VerticalAlignment="Center"
+                                                                    ToolTip.Tip="{l:Loc ProvidersView_NineRouterConnection_EditNameTooltip}"
+                                                                    IsEnabled="{Binding #Root.DataContext.IsNineRouterEngineRunning}"
+                                                                    Command="{Binding #Root.DataContext.EditNineRouterConnectionNameCommand}"
+                                                                    CommandParameter="{Binding}">
+                                                                <lucide:PackIconLucide Kind="Pencil" Width="13" Height="13" Foreground="{DynamicResource FgMutedBrush}" />
+                                                            </Button>
+                                                            <Button Grid.Column="3" Classes="icon-btn" VerticalAlignment="Center"
                                                                     ToolTip.Tip="{l:Loc ProvidersView_NineRouterConnection_DeleteTooltip}"
                                                                     Command="{Binding #Root.DataContext.DeleteNineRouterConnectionCommand}"
                                                                     CommandParameter="{Binding}">

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -117,21 +117,23 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
-    public async Task UpdateProviderAsync_PutsIsActive_ReturnsUpdatedConnection()
+    public async Task UpdateProviderAsync_PutsSuppliedFields_ReturnsUpdatedConnection()
     {
         using var handler = new FakeApiHandler();
         handler.EnqueueJson(HttpStatusCode.OK, """
-            { "connection": { "id": "conn-1", "provider": "openai", "name": "OpenAI", "isActive": false } }
+            { "connection": { "id": "conn-1", "provider": "openai", "name": "Personal", "isActive": false } }
             """);
         using var client = new ApiClient(Port, handler);
 
-        var updated = await client.UpdateProviderAsync("conn-1", new NineRouterUpdateProviderRequest { IsActive = false });
+        var updated = await client.UpdateProviderAsync("conn-1", new NineRouterUpdateProviderRequest { Name = "Personal", IsActive = false });
 
         Assert.Equal("conn-1", updated.Id);
+        Assert.Equal("Personal", updated.Name);
         Assert.False(updated.IsActive);
         Assert.Equal("PUT", handler.Requests[0].Method);
         Assert.Equal("/api/providers/conn-1", handler.Requests[0].Path);
         using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("Personal", body.RootElement.GetProperty("name").GetString());
         Assert.False(body.RootElement.GetProperty("isActive").GetBoolean());
         Assert.False(body.RootElement.TryGetProperty("apiKey", out _));
     }


### PR DESCRIPTION
## Summary
- allow renaming 9Router connections from Providers
- persist names through the 9Router management API

## Tests
- dotnet test (9Router and MainWindow view-model tests)