### PR TITLE
Add per-provider 9Router round robin

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
@@ -555,6 +555,9 @@
   <data name="ProvidersView_NineRouterSection_Description" xml:space="preserve">
     <value>Conexiones de proveedores almacenadas por el motor 9Router en ejecución.</value>
   </data>
+  <data name="ProvidersView_NineRouterProvider_RoundRobin" xml:space="preserve">
+    <value>Round robin</value>
+  </data>
   <data name="ProvidersView_NineRouterSection_AuthFiles" xml:space="preserve">
     <value>Las conexiones de 9Router las almacena el motor 9Router en ejecución.</value>
   </data>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -567,6 +567,9 @@
   <data name="ProvidersView_NineRouterSection_Description" xml:space="preserve">
     <value>Provider connections stored by the running 9Router engine.</value>
   </data>
+  <data name="ProvidersView_NineRouterProvider_RoundRobin" xml:space="preserve">
+    <value>Round Robin</value>
+  </data>
   <data name="ProvidersView_NineRouterSection_AuthFiles" xml:space="preserve">
     <value>9Router connections are stored by the running 9Router engine.</value>
   </data>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -1508,7 +1508,8 @@ SelectedSection is SectionKey.Logs;
         {
             using var client = new ApiClient(engine.Port);
             var connections = await client.ListProvidersAsync(token);
-            await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections));
+            var settings = await client.GetSettingsAsync(token);
+            await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections, settings));
             if (connections.Count == 0)
             {
                 await Dispatcher.UIThread.InvokeAsync(NineRouterModelGroups.Clear);
@@ -2832,6 +2833,40 @@ SelectedSection is SectionKey.Logs;
     }
 
     [RelayCommand]
+    private async Task ToggleNineRouterProviderRoundRobinAsync(NineRouterProviderViewModel? provider)
+    {
+        if (provider is null || !IsNineRouterEngineRunning || IsNineRouterBusy) return;
+        IsNineRouterBusy = true;
+        try
+        {
+            using var client = new ApiClient(NineRouterEngine.Port);
+            var settings = await client.GetSettingsAsync();
+            var strategies = new Dictionary<string, NineRouterProviderStrategy>(
+                settings.ProviderStrategies ?? [],
+                StringComparer.OrdinalIgnoreCase);
+            if (provider.IsRoundRobin)
+                strategies.Remove(provider.Id);
+            else
+                strategies[provider.Id] = new NineRouterProviderStrategy
+                {
+                    FallbackStrategy = "round-robin",
+                    StickyRoundRobinLimit = 1
+                };
+
+            await client.UpdateSettingsAsync(new NineRouterUpdateSettingsRequest { ProviderStrategies = strategies });
+            await RefreshNineRouterConnectionsAsync();
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            IsNineRouterBusy = false;
+        }
+    }
+
+    [RelayCommand]
     private async Task ToggleNineRouterConnectionAsync(NineRouterConnectionViewModel? connection)
     {
         if (connection is null || !IsNineRouterEngineRunning || IsNineRouterBusy) return;
@@ -2938,7 +2973,8 @@ SelectedSection is SectionKey.Logs;
         {
             using var client = new ApiClient(NineRouterEngine.Port);
             var connections = await client.ListProvidersAsync();
-            await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections));
+            var settings = await client.GetSettingsAsync();
+            await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections, settings));
         }
         catch (Exception ex)
         {
@@ -2949,10 +2985,14 @@ SelectedSection is SectionKey.Logs;
         }
     }
 
-    private void ApplyNineRouterConnections(IReadOnlyList<NineRouterProvider> connections)
+    private void ApplyNineRouterConnections(IReadOnlyList<NineRouterProvider> connections, NineRouterSettings settings)
     {
+        var strategies = settings.ProviderStrategies ?? [];
         var providers = NineRouterProviderCatalog.All
-            .Select(option => new NineRouterProviderViewModel(option))
+            .Select(option => new NineRouterProviderViewModel(
+                option,
+                strategies.TryGetValue(option.Id, out var strategy)
+                && string.Equals(strategy.FallbackStrategy, "round-robin", StringComparison.OrdinalIgnoreCase)))
             .ToDictionary(provider => provider.Id, StringComparer.OrdinalIgnoreCase);
         var accounts = new List<NineRouterConnectionViewModel>();
 
@@ -2961,11 +3001,14 @@ SelectedSection is SectionKey.Logs;
             var providerId = connection.Provider ?? "";
             if (!providers.TryGetValue(providerId, out var provider))
             {
-                provider = new NineRouterProviderViewModel(new NineRouterProviderOption(
-                    providerId,
-                    string.IsNullOrWhiteSpace(providerId) ? "Unknown provider" : providerId,
-                    NineRouterAuthModes.None,
-                    NineRouterOAuthFlow.None));
+                provider = new NineRouterProviderViewModel(
+                    new NineRouterProviderOption(
+                        providerId,
+                        string.IsNullOrWhiteSpace(providerId) ? "Unknown provider" : providerId,
+                        NineRouterAuthModes.None,
+                        NineRouterOAuthFlow.None),
+                    strategies.TryGetValue(providerId, out var strategy)
+                    && string.Equals(strategy.FallbackStrategy, "round-robin", StringComparison.OrdinalIgnoreCase));
                 providers.Add(providerId, provider);
             }
 

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterProviderViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterProviderViewModel.cs
@@ -11,9 +11,10 @@ public sealed partial class NineRouterProviderViewModel : ObservableObject
 {
     /// <summary>Initializes a provider row from its catalog entry.</summary>
     /// <param name="option">The provider metadata from the 9Router registry.</param>
-    public NineRouterProviderViewModel(NineRouterProviderOption option)
+    public NineRouterProviderViewModel(NineRouterProviderOption option, bool isRoundRobin = false)
     {
         Option = option;
+        IsRoundRobin = isRoundRobin;
         var icon = ProviderIconRegistry.GetDisplay(option.Id, option.Name);
         IconKind = icon.IconKind;
         LogoColor = icon.LogoColor;
@@ -87,6 +88,9 @@ public sealed partial class NineRouterProviderViewModel : ObservableObject
 
     /// <summary>Gets whether a Simple Icons glyph is available.</summary>
     public bool ShowSimpleIcon => !UseMonogram && !HasCustomIcon;
+
+    /// <summary>Gets or sets whether 9Router rotates this provider's accounts.</summary>
+    [ObservableProperty] private bool _isRoundRobin;
 
     /// <summary>Gets or sets whether the provider's connection list is expanded.</summary>
     [ObservableProperty] private bool _isExpanded;

--- a/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ProvidersView.axaml
@@ -308,6 +308,18 @@
                                                 </Panel>
                                             </Grid>
                                         </ToggleButton>
+                                        <Border Background="#08FFFFFF" Margin="16,0,16,4" CornerRadius="8" Padding="14,10"
+                                                IsVisible="{Binding IsExpanded}">
+                                            <Grid ColumnDefinitions="*,Auto">
+                                                <TextBlock Classes="row-label" Text="{l:Loc ProvidersView_NineRouterProvider_RoundRobin}"
+                                                           VerticalAlignment="Center" />
+                                                <ToggleButton Grid.Column="1" Classes="enable-toggle"
+                                                              IsChecked="{Binding IsRoundRobin, Mode=OneWay}"
+                                                              IsEnabled="{Binding #Root.DataContext.IsNineRouterEngineRunning}"
+                                                              Command="{Binding #Root.DataContext.ToggleNineRouterProviderRoundRobinCommand}"
+                                                              CommandParameter="{Binding}" />
+                                            </Grid>
+                                        </Border>
                                         <ItemsControl ItemsSource="{Binding Accounts}" IsVisible="{Binding IsExpanded}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="vm:NineRouterConnectionViewModel">

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -106,6 +106,28 @@ public sealed class ApiClient : IDisposable
         return payload.Connections ?? [];
     }
 
+    /// <summary>Gets routing settings via <c>GET /api/settings</c>.</summary>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterSettings> GetSettingsAsync(CancellationToken ct = default)
+    {
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Get, "api/settings", body: null, ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterSettings>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Updates routing settings via <c>PATCH /api/settings</c>.</summary>
+    /// <param name="request">Fields to change. Null properties are omitted.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterSettings> UpdateSettingsAsync(
+        NineRouterUpdateSettingsRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Patch, "api/settings", request, ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterSettings>(response, ct).ConfigureAwait(false);
+    }
+
     /// <summary>Creates an API-key connection via <c>POST /api/providers</c>.</summary>
     /// <param name="request">Provider id, display name, and API key.</param>
     /// <param name="ct">Token used to cancel the request.</param>

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace TunnelAgent.Infrastructure.Engine.NineRouter;
 
@@ -80,6 +82,34 @@ public sealed record NineRouterProvider
 
     /// <summary>Gets provider-specific extra fields such as <c>baseUrl</c> or proxy settings.</summary>
     public JsonElement? ProviderSpecificData { get; init; }
+}
+
+/// <summary>9Router routing settings returned by <c>GET /api/settings</c>.</summary>
+public sealed record NineRouterSettings
+{
+    /// <summary>Gets per-provider routing overrides keyed by provider id.</summary>
+    public Dictionary<string, NineRouterProviderStrategy> ProviderStrategies { get; init; } = [];
+}
+
+/// <summary>Routing override for one 9Router provider.</summary>
+public sealed record NineRouterProviderStrategy
+{
+    /// <summary>Gets the account-selection strategy, such as <c>round-robin</c>.</summary>
+    public string? FallbackStrategy { get; init; }
+
+    /// <summary>Gets the number of calls to make before rotating accounts.</summary>
+    public int? StickyRoundRobinLimit { get; init; }
+
+    /// <summary>Gets provider-specific settings that Tunnel Agent does not manage.</summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalData { get; init; }
+}
+
+/// <summary>Body for <c>PATCH /api/settings</c> when replacing provider routing overrides.</summary>
+public sealed record NineRouterUpdateSettingsRequest
+{
+    /// <summary>Gets the complete per-provider routing-override map.</summary>
+    public required Dictionary<string, NineRouterProviderStrategy> ProviderStrategies { get; init; }
 }
 
 /// <summary>

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -56,6 +56,38 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
+    public async Task SettingsAsync_GetsAndPatchesProviderStrategies()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "providerStrategies": { "anthropic": { "fallbackStrategy": "round-robin", "stickyRoundRobinLimit": 2 } } }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "providerStrategies": { "openai": { "fallbackStrategy": "round-robin", "stickyRoundRobinLimit": 1 } } }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var settings = await client.GetSettingsAsync();
+        var updated = await client.UpdateSettingsAsync(new NineRouterUpdateSettingsRequest
+        {
+            ProviderStrategies = new Dictionary<string, NineRouterProviderStrategy>
+            {
+                ["openai"] = new() { FallbackStrategy = "round-robin", StickyRoundRobinLimit = 1 }
+            }
+        });
+
+        Assert.Equal("round-robin", settings.ProviderStrategies["anthropic"].FallbackStrategy);
+        Assert.Equal("round-robin", updated.ProviderStrategies["openai"].FallbackStrategy);
+        Assert.Equal("GET", handler.Requests[0].Method);
+        Assert.Equal("/api/settings", handler.Requests[0].Path);
+        Assert.Equal("PATCH", handler.Requests[1].Method);
+        using var body = JsonDocument.Parse(handler.Requests[1].Body!);
+        var strategy = body.RootElement.GetProperty("providerStrategies").GetProperty("openai");
+        Assert.Equal("round-robin", strategy.GetProperty("fallbackStrategy").GetString());
+        Assert.Equal(1, strategy.GetProperty("stickyRoundRobinLimit").GetInt32());
+    }
+
+    [Fact]
     public async Task CreateProviderAsync_PostsCamelCaseBody_Returns201Connection()
     {
         using var handler = new FakeApiHandler();


### PR DESCRIPTION
## Summary\n- add a per-provider Round Robin toggle in 9Router Providers\n- persist provider strategy overrides through the 9Router settings API\n\n## Tests\n- dotnet test (9Router API client and provider view-model tests)