### PR TITLE
Add 9Router combo management

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
@@ -71,6 +71,12 @@
   <data name="Sidebar_Fallback" xml:space="preserve">
     <value>Fallback</value>
   </data>
+  <data name="Sidebar_FallbackCliProxy" xml:space="preserve">
+    <value>Fallback (CLIProxyAPI)</value>
+  </data>
+  <data name="Sidebar_NineRouterCombos" xml:space="preserve">
+    <value>Combos (9R)</value>
+  </data>
   <data name="Fallback_Title" xml:space="preserve">
     <value>Fallback de modelos</value>
   </data>
@@ -558,6 +564,75 @@
   <data name="ProvidersView_NineRouterProvider_RoundRobin" xml:space="preserve">
     <value>Round robin</value>
   </data>
+  <data name="NineRouterCombos_Title" xml:space="preserve">
+    <value>Combos de 9Router</value>
+  </data>
+  <data name="NineRouterCombos_Subtitle" xml:space="preserve">
+    <value>Agrupa modelos para fallback ordenado o round robin.</value>
+  </data>
+  <data name="NineRouterCombos_Refresh" xml:space="preserve">
+    <value>Actualizar combos</value>
+  </data>
+  <data name="NineRouterCombos_Create" xml:space="preserve">
+    <value>Crear combo</value>
+  </data>
+  <data name="NineRouterCombos_Edit" xml:space="preserve">
+    <value>Editar combo</value>
+  </data>
+  <data name="NineRouterCombos_Save" xml:space="preserve">
+    <value>Guardar cambios</value>
+  </data>
+  <data name="NineRouterCombos_CreateSubtitle" xml:space="preserve">
+    <value>Añade los modelos en su orden de fallback.</value>
+  </data>
+  <data name="NineRouterCombos_Models" xml:space="preserve">
+    <value>Modelos</value>
+  </data>
+  <data name="NineRouterCombos_ModelCount" xml:space="preserve">
+    <value>{0} modelos</value>
+  </data>
+  <data name="NineRouterCombos_DraftEmpty" xml:space="preserve">
+    <value>Añade al menos un modelo para crear el combo.</value>
+  </data>
+  <data name="NineRouterCombos_Strategy" xml:space="preserve">
+    <value>Estrategia</value>
+  </data>
+  <data name="NineRouterCombos_StrategyFallback" xml:space="preserve">
+    <value>Fallback — probar en orden</value>
+  </data>
+  <data name="NineRouterCombos_StrategyRoundRobin" xml:space="preserve">
+    <value>Round Robin — rotar</value>
+  </data>
+  <data name="NineRouterCombos_StrategyFusion" xml:space="preserve">
+    <value>Fusion — panel + juez</value>
+  </data>
+  <data name="NineRouterCombos_Judge" xml:space="preserve">
+    <value>Modelo juez</value>
+  </data>
+  <data name="NineRouterCombos_JudgeAuto" xml:space="preserve">
+    <value>Automático: usa el primer modelo si no seleccionas otro.</value>
+  </data>
+  <data name="NineRouterCombos_EngineNotRunning" xml:space="preserve">
+    <value>Inicia 9Router antes de administrar los combos.</value>
+  </data>
+  <data name="NineRouterCombos_Name" xml:space="preserve">
+    <value>Nombre del combo</value>
+  </data>
+  <data name="NineRouterCombos_NamePlaceholder" xml:space="preserve">
+    <value>mi-combo</value>
+  </data>
+  <data name="NineRouterCombos_AddModel" xml:space="preserve">
+    <value>Añadir modelo</value>
+  </data>
+  <data name="NineRouterCombos_NoModelsAvailable" xml:space="preserve">
+    <value>Aún no hay modelos de 9Router disponibles.</value>
+  </data>
+  <data name="NineRouterCombos_Empty" xml:space="preserve">
+    <value>Aún no hay combos.</value>
+  </data>
+  <data name="NineRouterCombos_RoundRobin" xml:space="preserve">
+    <value>Round robin</value>
+  </data>
   <data name="ProvidersView_NineRouterSection_AuthFiles" xml:space="preserve">
     <value>Las conexiones de 9Router las almacena el motor 9Router en ejecución.</value>
   </data>
@@ -600,9 +675,6 @@
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Eliminar conexión</value>
   </data>
-  <data name="ProvidersView_NineRouterConnection_EditNameTooltip" xml:space="preserve">
-    <value>Editar nombre de conexión</value>
-  </data>
   <data name="ProvidersView_NineRouter_EngineNotRunning" xml:space="preserve">
     <value>Inicia 9Router antes de gestionar las conexiones.</value>
   </data>
@@ -611,9 +683,6 @@
   </data>
   <data name="ProvidersView_NineRouter_LoadFailed" xml:space="preserve">
     <value>No se pudieron cargar las conexiones de 9Router: {0}</value>
-  </data>
-  <data name="Dialog_EditNineRouterConnectionName_Title" xml:space="preserve">
-    <value>Editar nombre de conexión de 9Router</value>
   </data>
   <data name="Dialog_AddNineRouterKey_Title" xml:space="preserve">
     <value>Añadir clave API</value>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -73,6 +73,12 @@
   <data name="Sidebar_Fallback" xml:space="preserve">
     <value>Fallback</value>
   </data>
+  <data name="Sidebar_FallbackCliProxy" xml:space="preserve">
+    <value>Fallback (CLIProxyAPI)</value>
+  </data>
+  <data name="Sidebar_NineRouterCombos" xml:space="preserve">
+    <value>Combos (9Router)</value>
+  </data>
   <data name="Fallback_Title" xml:space="preserve">
     <value>Model Fallback</value>
   </data>
@@ -570,6 +576,75 @@
   <data name="ProvidersView_NineRouterProvider_RoundRobin" xml:space="preserve">
     <value>Round Robin</value>
   </data>
+  <data name="NineRouterCombos_Title" xml:space="preserve">
+    <value>9Router combos</value>
+  </data>
+  <data name="NineRouterCombos_Subtitle" xml:space="preserve">
+    <value>Group models for ordered fallback or round robin.</value>
+  </data>
+  <data name="NineRouterCombos_Refresh" xml:space="preserve">
+    <value>Refresh combos</value>
+  </data>
+  <data name="NineRouterCombos_Create" xml:space="preserve">
+    <value>Create combo</value>
+  </data>
+  <data name="NineRouterCombos_Edit" xml:space="preserve">
+    <value>Edit combo</value>
+  </data>
+  <data name="NineRouterCombos_Save" xml:space="preserve">
+    <value>Save changes</value>
+  </data>
+  <data name="NineRouterCombos_CreateSubtitle" xml:space="preserve">
+    <value>Add models in their fallback order.</value>
+  </data>
+  <data name="NineRouterCombos_Models" xml:space="preserve">
+    <value>Models</value>
+  </data>
+  <data name="NineRouterCombos_ModelCount" xml:space="preserve">
+    <value>{0} models</value>
+  </data>
+  <data name="NineRouterCombos_DraftEmpty" xml:space="preserve">
+    <value>Add at least one model to create the combo.</value>
+  </data>
+  <data name="NineRouterCombos_Strategy" xml:space="preserve">
+    <value>Strategy</value>
+  </data>
+  <data name="NineRouterCombos_StrategyFallback" xml:space="preserve">
+    <value>Fallback — try in order</value>
+  </data>
+  <data name="NineRouterCombos_StrategyRoundRobin" xml:space="preserve">
+    <value>Round Robin — rotate</value>
+  </data>
+  <data name="NineRouterCombos_StrategyFusion" xml:space="preserve">
+    <value>Fusion — panel + judge</value>
+  </data>
+  <data name="NineRouterCombos_Judge" xml:space="preserve">
+    <value>Judge model</value>
+  </data>
+  <data name="NineRouterCombos_JudgeAuto" xml:space="preserve">
+    <value>Automatic: uses the first model if none is selected.</value>
+  </data>
+  <data name="NineRouterCombos_EngineNotRunning" xml:space="preserve">
+    <value>Start 9Router before managing combos.</value>
+  </data>
+  <data name="NineRouterCombos_Name" xml:space="preserve">
+    <value>Combo name</value>
+  </data>
+  <data name="NineRouterCombos_NamePlaceholder" xml:space="preserve">
+    <value>my-combo</value>
+  </data>
+  <data name="NineRouterCombos_AddModel" xml:space="preserve">
+    <value>Add model</value>
+  </data>
+  <data name="NineRouterCombos_NoModelsAvailable" xml:space="preserve">
+    <value>No 9Router models available yet.</value>
+  </data>
+  <data name="NineRouterCombos_Empty" xml:space="preserve">
+    <value>No combos yet.</value>
+  </data>
+  <data name="NineRouterCombos_RoundRobin" xml:space="preserve">
+    <value>Round robin</value>
+  </data>
   <data name="ProvidersView_NineRouterSection_AuthFiles" xml:space="preserve">
     <value>9Router connections are stored by the running 9Router engine.</value>
   </data>
@@ -612,9 +687,6 @@
   <data name="ProvidersView_NineRouterConnection_DeleteTooltip" xml:space="preserve">
     <value>Delete connection</value>
   </data>
-  <data name="ProvidersView_NineRouterConnection_EditNameTooltip" xml:space="preserve">
-    <value>Edit connection name</value>
-  </data>
   <data name="ProvidersView_NineRouter_EngineNotRunning" xml:space="preserve">
     <value>Start 9Router before managing connections.</value>
   </data>
@@ -623,9 +695,6 @@
   </data>
   <data name="ProvidersView_NineRouter_LoadFailed" xml:space="preserve">
     <value>Could not load 9Router connections: {0}</value>
-  </data>
-  <data name="Dialog_EditNineRouterConnectionName_Title" xml:space="preserve">
-    <value>Edit 9Router connection name</value>
   </data>
   <data name="Dialog_AddNineRouterKey_Title" xml:space="preserve">
     <value>Add API key</value>

--- a/src/TunnelAgent.Avalonia/Themes/Controls.axaml
+++ b/src/TunnelAgent.Avalonia/Themes/Controls.axaml
@@ -316,6 +316,14 @@
     <Style Selector="Button.side.selected lucide|PackIconLucide">
         <Setter Property="Foreground" Value="White" />
     </Style>
+    <Style Selector="Button.side-sub">
+        <Setter Property="Padding" Value="8,5" />
+        <Setter Property="Margin" Value="0,0,0,1" />
+    </Style>
+    <Style Selector="Button.side-sub.selected /template/ ContentPresenter">
+        <Setter Property="Background" Value="{DynamicResource AccentSoftBrush}" />
+        <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentBrush}" />
+    </Style>
 
     <!-- Sidebar footer proxy status card (Quotio-style) -->
     <Style Selector="Button.proxy-card">

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -96,6 +96,7 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
     public LogsViewModel Logs { get; } = new();
     public DashboardViewModel Dashboard { get; } = new();
     public FallbackViewModel Fallback { get; }
+    public NineRouterCombosViewModel NineRouterCombos { get; }
     private bool _logsInitialLoadPending;
     private bool _isWindowVisibleForLogs = true;
     private bool _managementKeyRepairAttempted;
@@ -161,6 +162,7 @@ SelectedSection is SectionKey.Logs;
 
     [ObservableProperty] private SectionKey _selectedSection = SectionKey.Home;
     [ObservableProperty] private bool _isSidebarCollapsed;
+    [ObservableProperty] private bool _isFallbackSubmenuExpanded;
     [ObservableProperty] private bool _isDark;
     [ObservableProperty] private string _focusedConfigEngineId = EngineCatalog.CliProxyApi.Id;
     [ObservableProperty] private string _providersEngineId = EngineCatalog.CliProxyApi.Id;
@@ -449,6 +451,10 @@ SelectedSection is SectionKey.Logs;
         PerplexityModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
         NineRouterModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
         AvailableModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
+        NineRouterCombos = new NineRouterCombosViewModel(
+            () => NineRouterEngine.Port,
+            () => IsNineRouterEngineRunning,
+            NineRouterModelGroups);
 
         void OnEngineModelsChanged(object? s, System.Collections.Specialized.NotifyCollectionChangedEventArgs _)
         {
@@ -1599,6 +1605,7 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(NineRouterEndpointUrl));
         OnPropertyChanged(nameof(NineRouterDashboardUrl));
         OnPropertyChanged(nameof(IsNineRouterEngineRunning));
+        NineRouterCombos.NotifyEngineStateChanged();
         OnPropertyChanged(nameof(EndpointUrl));
         OnPropertyChanged(nameof(Port));
         OnPropertyChanged(nameof(EditablePort));
@@ -3420,7 +3427,22 @@ SelectedSection is SectionKey.Logs;
     private void SelectAgents() => SelectedSection = SectionKey.Agents;
 
     [RelayCommand]
-    private void SelectFallback() => SelectedSection = SectionKey.Fallback;
+    private void ToggleFallbackSubmenu() => IsFallbackSubmenuExpanded = !IsFallbackSubmenuExpanded;
+
+    [RelayCommand]
+    private void SelectFallback()
+    {
+        IsFallbackSubmenuExpanded = true;
+        SelectedSection = SectionKey.Fallback;
+    }
+
+    [RelayCommand]
+    private void SelectNineRouterCombos()
+    {
+        IsFallbackSubmenuExpanded = true;
+        SelectedSection = SectionKey.NineRouterCombos;
+        NineRouterCombos.RefreshCommand.Execute(null);
+    }
 
     private void RefreshFallbackModelOptions()
     {

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterCombosViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterCombosViewModel.cs
@@ -1,0 +1,369 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+
+namespace TunnelAgent.ViewModels;
+
+/// <summary>One ordered model in a 9Router combo.</summary>
+public sealed class NineRouterComboModelViewModel
+{
+    /// <summary>Creates a model entry.</summary>
+    public NineRouterComboModelViewModel(int position, string name)
+    {
+        Position = position;
+        Name = name;
+    }
+
+    /// <summary>Gets the one-based fallback position.</summary>
+    public int Position { get; }
+
+    /// <summary>Gets the 9Router model identifier.</summary>
+    public string Name { get; }
+}
+
+/// <summary>One 9Router model combo shown in the Fallback view.</summary>
+public sealed partial class NineRouterComboViewModel : ObservableObject
+{
+    /// <summary>Creates a view model for a 9Router combo.</summary>
+    /// <param name="combo">Combo returned by 9Router.</param>
+    /// <param name="strategy">The routing strategy for the combo.</param>
+    /// <param name="judgeModel">Optional model that judges Fusion responses.</param>
+    public NineRouterComboViewModel(NineRouterCombo combo, string? strategy, string? judgeModel)
+    {
+        Id = combo.Id ?? "";
+        Name = combo.Name ?? "";
+        Models = (combo.Models ?? [])
+            .Select((name, index) => new NineRouterComboModelViewModel(index + 1, name))
+            .ToList();
+        Strategy = NormalizeStrategy(strategy);
+        JudgeModel = judgeModel;
+    }
+
+    /// <summary>Gets the combo id used by 9Router.</summary>
+    public string Id { get; }
+
+    /// <summary>Gets the combo name exposed as a model.</summary>
+    public string Name { get; }
+
+    /// <summary>Gets the ordered models in the combo.</summary>
+    public IReadOnlyList<NineRouterComboModelViewModel> Models { get; }
+
+    /// <summary>Gets the number of models in the combo.</summary>
+    public int ModelCount => Models.Count;
+
+    /// <summary>Gets or sets the routing strategy.</summary>
+    [ObservableProperty] private string _strategy = "fallback";
+
+    /// <summary>Gets or sets the optional Fusion judge model.</summary>
+    [ObservableProperty] private string? _judgeModel;
+
+    /// <summary>Gets or sets whether combo details are expanded.</summary>
+    [ObservableProperty] private bool _isExpanded;
+
+    private static string NormalizeStrategy(string? strategy) => strategy switch
+    {
+        "round-robin" => "round-robin",
+        "fusion" => "fusion",
+        _ => "fallback"
+    };
+}
+
+/// <summary>Loads and manages 9Router model combos.</summary>
+public sealed partial class NineRouterCombosViewModel : ObservableObject
+{
+    private readonly Func<int> _port;
+    private readonly Func<bool> _isEngineRunning;
+    private readonly ObservableCollection<AvailableModelGroupViewModel> _modelGroups;
+    private string? _editingComboId;
+    private string? _editingComboName;
+
+    [ObservableProperty] private bool _isBusy;
+    [ObservableProperty] private bool _showCreatePanel;
+    [ObservableProperty] private string _nameDraft = "";
+    [ObservableProperty] private string? _selectedModel;
+    [ObservableProperty] private string _draftStrategy = "fallback";
+    [ObservableProperty] private string? _draftJudgeModel;
+    [ObservableProperty] private string? _errorMessage;
+
+    /// <summary>Gets the 9Router combos.</summary>
+    public ObservableCollection<NineRouterComboViewModel> Combos { get; } = [];
+
+    /// <summary>Gets the ordered models for the combo being created.</summary>
+    public ObservableCollection<string> DraftModels { get; } = [];
+
+    /// <summary>Gets all models reported by 9Router.</summary>
+    public IReadOnlyList<string> AvailableModels => _modelGroups
+        .SelectMany(group => group.Models.Select(model => model.Name))
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .OrderBy(model => model, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+
+    /// <summary>Gets whether at least one combo exists.</summary>
+    public bool HasCombos => Combos.Count > 0;
+
+    /// <summary>Gets whether 9Router is running.</summary>
+    public bool IsEngineRunning => _isEngineRunning();
+
+    /// <summary>Gets whether the draft contains at least one model.</summary>
+    public bool HasDraftModels => DraftModels.Count > 0;
+
+    /// <summary>Gets whether 9Router has reported any models to choose from.</summary>
+    public bool HasAvailableModels => AvailableModels.Count > 0;
+
+    /// <summary>Gets whether the dialog has the required values.</summary>
+    public bool CanSubmit => IsValidName(NameDraft.Trim()) && DraftModels.Count > 0 && IsEngineRunning && !IsBusy;
+
+    /// <summary>Gets whether the dialog is editing an existing combo.</summary>
+    public bool IsEditing => _editingComboId is not null;
+
+    /// <summary>Gets whether the creation dialog has Fusion selected.</summary>
+    public bool IsDraftFusion => string.Equals(DraftStrategy, "fusion", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Gets or sets the strategy index used by the creation dialog selector.</summary>
+    public int DraftStrategyIndex
+    {
+        get => DraftStrategy switch { "round-robin" => 1, "fusion" => 2, _ => 0 };
+        set => DraftStrategy = value switch { 1 => "round-robin", 2 => "fusion", _ => "fallback" };
+    }
+
+    /// <summary>Gets whether an operation error should be displayed.</summary>
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+
+    /// <summary>Initializes combo management against the active 9Router engine.</summary>
+    /// <param name="port">Gets the active 9Router management port.</param>
+    /// <param name="isEngineRunning">Gets whether 9Router is available.</param>
+    /// <param name="modelGroups">Models reported by 9Router.</param>
+    public NineRouterCombosViewModel(
+        Func<int> port,
+        Func<bool> isEngineRunning,
+        ObservableCollection<AvailableModelGroupViewModel> modelGroups)
+    {
+        _port = port;
+        _isEngineRunning = isEngineRunning;
+        _modelGroups = modelGroups;
+        _modelGroups.CollectionChanged += (_, _) =>
+        {
+            OnPropertyChanged(nameof(AvailableModels));
+            OnPropertyChanged(nameof(HasAvailableModels));
+        };
+        Combos.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasCombos));
+        DraftModels.CollectionChanged += (_, _) =>
+        {
+            OnPropertyChanged(nameof(CanSubmit));
+            OnPropertyChanged(nameof(HasDraftModels));
+        };
+    }
+
+    partial void OnNameDraftChanged(string value) => OnPropertyChanged(nameof(CanSubmit));
+    partial void OnIsBusyChanged(bool value) => OnPropertyChanged(nameof(CanSubmit));
+    partial void OnDraftStrategyChanged(string value)
+    {
+        OnPropertyChanged(nameof(DraftStrategyIndex));
+        OnPropertyChanged(nameof(IsDraftFusion));
+    }
+    partial void OnErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasError));
+
+    /// <summary>Refreshes engine-dependent state when the 9Router process changes state.</summary>
+    public void NotifyEngineStateChanged()
+    {
+        OnPropertyChanged(nameof(IsEngineRunning));
+        OnPropertyChanged(nameof(CanSubmit));
+        if (!IsEngineRunning)
+            CloseCreatePanel();
+    }
+
+    /// <summary>Loads combos and their strategy overrides from 9Router.</summary>
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        if (!_isEngineRunning())
+        {
+            Combos.Clear();
+            return;
+        }
+
+        IsBusy = true;
+        ErrorMessage = null;
+        try
+        {
+            using var client = new ApiClient(_port());
+            var combos = await client.ListCombosAsync();
+            var settings = await client.GetSettingsAsync();
+            Combos.Clear();
+            foreach (var combo in combos.OrderBy(combo => combo.Name, StringComparer.OrdinalIgnoreCase))
+            {
+                settings.ComboStrategies.TryGetValue(combo.Name ?? "", out var strategy);
+                Combos.Add(new NineRouterComboViewModel(combo, strategy?.FallbackStrategy, strategy?.JudgeModel));
+            }
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>Opens the combo creation dialog.</summary>
+    [RelayCommand]
+    private void OpenCreatePanel()
+    {
+        if (!IsEngineRunning) return;
+        _editingComboId = null;
+        _editingComboName = null;
+        OnPropertyChanged(nameof(IsEditing));
+        ErrorMessage = null;
+        NameDraft = "";
+        DraftModels.Clear();
+        SelectedModel = AvailableModels.FirstOrDefault();
+        DraftStrategy = "fallback";
+        DraftJudgeModel = null;
+        ShowCreatePanel = true;
+    }
+
+    /// <summary>Opens an existing combo in the editor.</summary>
+    [RelayCommand]
+    private void OpenEditPanel(NineRouterComboViewModel? combo)
+    {
+        if (combo is null || !IsEngineRunning) return;
+        _editingComboId = combo.Id;
+        _editingComboName = combo.Name;
+        OnPropertyChanged(nameof(IsEditing));
+        ErrorMessage = null;
+        NameDraft = combo.Name;
+        DraftModels.Clear();
+        foreach (var model in combo.Models)
+            DraftModels.Add(model.Name);
+        SelectedModel = AvailableModels.FirstOrDefault();
+        DraftStrategy = combo.Strategy;
+        DraftJudgeModel = combo.JudgeModel;
+        ShowCreatePanel = true;
+    }
+
+    /// <summary>Closes and clears the combo dialog.</summary>
+    [RelayCommand]
+    private void CloseCreatePanel()
+    {
+        ShowCreatePanel = false;
+        _editingComboId = null;
+        _editingComboName = null;
+        OnPropertyChanged(nameof(IsEditing));
+        NameDraft = "";
+        DraftModels.Clear();
+        SelectedModel = null;
+        DraftStrategy = "fallback";
+        DraftJudgeModel = null;
+        ErrorMessage = null;
+    }
+
+    /// <summary>Adds the selected model to the combo in creation order.</summary>
+    [RelayCommand]
+    private void AddModel()
+    {
+        if (string.IsNullOrWhiteSpace(SelectedModel) || DraftModels.Contains(SelectedModel, StringComparer.OrdinalIgnoreCase)) return;
+        DraftModels.Add(SelectedModel);
+    }
+
+    /// <summary>Moves a draft model one position earlier.</summary>
+    [RelayCommand]
+    private void MoveDraftModelUp(string? model) => MoveDraftModel(model, -1);
+
+    /// <summary>Moves a draft model one position later.</summary>
+    [RelayCommand]
+    private void MoveDraftModelDown(string? model) => MoveDraftModel(model, 1);
+
+    /// <summary>Removes a model from the draft combo.</summary>
+    [RelayCommand]
+    private void RemoveDraftModel(string? model)
+    {
+        if (model is not null) DraftModels.Remove(model);
+    }
+
+    /// <summary>Creates or updates the combo through the 9Router management API.</summary>
+    [RelayCommand]
+    private async Task SaveComboAsync()
+    {
+        var name = NameDraft.Trim();
+        if (!CanSubmit) return;
+
+        IsBusy = true;
+        ErrorMessage = null;
+        try
+        {
+            var strategy = DraftStrategy;
+            var judgeModel = DraftJudgeModel;
+            var previousName = _editingComboName;
+            using var client = new ApiClient(_port());
+            if (_editingComboId is null)
+                await client.CreateComboAsync(new NineRouterCreateComboRequest { Name = name, Models = [.. DraftModels] });
+            else
+                await client.UpdateComboAsync(_editingComboId, new NineRouterUpdateComboRequest { Name = name, Models = [.. DraftModels] });
+
+            var settings = await client.GetSettingsAsync();
+            if (previousName is not null && !string.Equals(previousName, name, StringComparison.Ordinal))
+                settings.ComboStrategies.Remove(previousName);
+            settings.ComboStrategies[name] = new NineRouterComboStrategy
+            {
+                FallbackStrategy = strategy,
+                JudgeModel = strategy == "fusion" ? judgeModel : null
+            };
+            await client.UpdateComboStrategiesAsync(settings.ComboStrategies);
+            CloseCreatePanel();
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    /// <summary>Deletes a combo through the 9Router management API.</summary>
+    [RelayCommand]
+    private async Task DeleteAsync(NineRouterComboViewModel? combo)
+    {
+        if (combo is null || !_isEngineRunning() || IsBusy) return;
+
+        IsBusy = true;
+        ErrorMessage = null;
+        try
+        {
+            using var client = new ApiClient(_port());
+            await client.DeleteComboAsync(combo.Id);
+            var settings = await client.GetSettingsAsync();
+            if (settings.ComboStrategies.Remove(combo.Name))
+                await client.UpdateComboStrategiesAsync(settings.ComboStrategies);
+            await RefreshAsync();
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void MoveDraftModel(string? model, int offset)
+    {
+        if (model is null) return;
+        var index = DraftModels.IndexOf(model);
+        var target = index + offset;
+        if (index >= 0 && target >= 0 && target < DraftModels.Count)
+            DraftModels.Move(index, target);
+    }
+
+    private static bool IsValidName(string name) => name.Length > 0 && name.All(character =>
+        char.IsLetterOrDigit(character) || character is '.' or '_' or '-');
+}

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -216,24 +216,34 @@
                                 </Grid>
                             </Button>
 
-                            <Button Classes="side"
-                                    Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Fallback}"
-                                    Command="{Binding SelectFallbackCommand}">
-                                <Grid ColumnDefinitions="20,*">
-                                    <lucide:PackIconLucide Grid.Column="0" Kind="GitFork" Width="15" Height="15"
-                                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                    <Panel Grid.Column="1"
-                                           Opacity="{Binding SidebarContentOpacity}">
-                                        <Panel.Transitions>
-                                            <Transitions>
-                                                <DoubleTransition Property="Opacity" Duration="0:0:0.18" Easing="CubicEaseInOut" />
-                                            </Transitions>
-                                        </Panel.Transitions>
-                                        <TextBlock Text="{l:Loc Sidebar_Fallback}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
-                                                   IsVisible="{Binding !IsSidebarCollapsed}"/>
-                                    </Panel>
-                                </Grid>
-                            </Button>
+                            <StackPanel Spacing="2">
+                                <Button Classes="side" Command="{Binding ToggleFallbackSubmenuCommand}">
+                                    <Grid ColumnDefinitions="20,*,Auto">
+                                        <lucide:PackIconLucide Grid.Column="0" Kind="GitFork" Width="15" Height="15"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="1" Text="{l:Loc Sidebar_Fallback}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
+                                                   Opacity="{Binding SidebarContentOpacity}" IsVisible="{Binding !IsSidebarCollapsed}" />
+                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center" IsVisible="{Binding !IsSidebarCollapsed}">
+                                            <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
+                                                                    IsVisible="{Binding IsFallbackSubmenuExpanded, Converter={StaticResource InvertBool}}" />
+                                            <lucide:PackIconLucide Kind="ChevronDown" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
+                                                                    IsVisible="{Binding IsFallbackSubmenuExpanded}" />
+                                        </Panel>
+                                    </Grid>
+                                </Button>
+                                <StackPanel Spacing="2" Margin="18,0,0,0" IsVisible="{Binding IsFallbackSubmenuExpanded}">
+                                    <Button Classes="side side-sub" Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Fallback}"
+                                            Command="{Binding SelectFallbackCommand}">
+                                        <TextBlock Text="{l:Loc Sidebar_FallbackCliProxy}" FontSize="11" Margin="0"
+                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                    </Button>
+                                    <Button Classes="side side-sub" Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=NineRouterCombos}"
+                                            Command="{Binding SelectNineRouterCombosCommand}">
+                                        <TextBlock Text="{l:Loc Sidebar_NineRouterCombos}" FontSize="11" Margin="0"
+                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                    </Button>
+                                </StackPanel>
+                            </StackPanel>
 
                             <Button Classes="side"
                                     Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Agents}"
@@ -1054,6 +1064,8 @@
                 </StackPanel>
             </Border>
         </Border>
+
+        <v:NineRouterComboOverlayView DataContext="{Binding}" ZIndex="50" />
 
         <ContentControl x:Name="AgentConfigOverlayHost"
                         IsVisible="{Binding ShowAgentConfigDialog}"

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
@@ -53,8 +53,16 @@ public partial class MainWindow : Window
         var selected = SidebarNavItems.Children
             .OfType<Button>()
             .FirstOrDefault(b => b.Classes.Contains("selected"));
-        if (selected is null) return;
+        if (selected is null)
+        {
+            SidebarPill.IsVisible = false;
+            return;
+        }
 
+        // A pill returning from a selected submenu must snap in, not animate
+        // from the last top-level item.
+        var wasVisible = SidebarPill.IsVisible;
+        SidebarPill.IsVisible = true;
         var bounds = selected.Bounds;
         if (bounds.Height <= 0) return;
 
@@ -62,7 +70,7 @@ public partial class MainWindow : Window
         SidebarPill.Height = bounds.Height;
         translate.X = bounds.X;
 
-        if (animate)
+        if (animate && wasVisible)
         {
             translate.Y = bounds.Y;
         }
@@ -198,6 +206,7 @@ public partial class MainWindow : Window
         SectionKey.Providers => new ProvidersView(),
         SectionKey.Quota => new QuotaView(),
         SectionKey.Fallback => new FallbackView(),
+        SectionKey.NineRouterCombos => new NineRouterCombosView(),
         SectionKey.Agents => new AgentsView(),
         SectionKey.Logs => new LogsView(),
         SectionKey.Configuration => new ConfigurationView(),

--- a/src/TunnelAgent.Avalonia/Views/NineRouterComboOverlayView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/NineRouterComboOverlayView.axaml
@@ -1,0 +1,107 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:TunnelAgent.ViewModels"
+             xmlns:lucide="using:IconPacks.Avalonia.Lucide"
+             xmlns:l="using:TunnelAgent.Services"
+             x:Class="TunnelAgent.Views.NineRouterComboOverlayView"
+             x:Name="Root"
+             x:DataType="vm:MainWindowViewModel">
+    <Border Background="#88000000" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="20"
+            DataContext="{Binding NineRouterCombos}" IsVisible="{Binding ShowCreatePanel}"
+            Focusable="True" KeyDown="OnDialogKeyDown" PointerPressed="OnOverlayPressed">
+        <Border Classes="card" Width="520" MaxHeight="620" HorizontalAlignment="Center" VerticalAlignment="Center" Padding="0"
+                PointerPressed="OnDialogCardPressed">
+            <Grid RowDefinitions="Auto,Auto,*,Auto">
+                <Grid Grid.Row="0" Margin="18,14" ColumnDefinitions="Auto,*,Auto">
+                    <lucide:PackIconLucide Kind="GitFork" Width="20" Height="20" VerticalAlignment="Top" Margin="0,2,0,0"
+                                           Foreground="{DynamicResource FgMutedBrush}" />
+                    <StackPanel Grid.Column="1" Margin="8,0,0,0" Spacing="2">
+                        <TextBlock Classes="row-label" FontSize="14" Text="{l:Loc NineRouterCombos_Create}" IsVisible="{Binding !IsEditing}" />
+                        <TextBlock Classes="row-label" FontSize="14" Text="{l:Loc NineRouterCombos_Edit}" IsVisible="{Binding IsEditing}" />
+                        <TextBlock Classes="row-desc" Text="{l:Loc NineRouterCombos_CreateSubtitle}" TextWrapping="Wrap" />
+                    </StackPanel>
+                    <Button Grid.Column="2" Classes="icon" VerticalAlignment="Top"
+                            Command="{Binding #Root.DataContext.NineRouterCombos.CloseCreatePanelCommand}">
+                        <lucide:PackIconLucide Kind="X" Width="14" Height="14" />
+                    </Button>
+                </Grid>
+
+                <Border Grid.Row="1" Classes="row-divider" />
+
+                <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                    <StackPanel Margin="18,14,18,24" Spacing="14">
+                        <StackPanel Spacing="6">
+                            <TextBlock Classes="section-label" Text="{l:Loc NineRouterCombos_Name}" Margin="2,0" />
+                            <TextBox Classes="app" Text="{Binding NameDraft, Mode=TwoWay}"
+                                     Watermark="{l:Loc NineRouterCombos_NamePlaceholder}" />
+                        </StackPanel>
+
+                        <StackPanel Spacing="6">
+                            <TextBlock Classes="section-label" Text="{l:Loc NineRouterCombos_Strategy}" Margin="2,0" />
+                            <ComboBox SelectedIndex="{Binding DraftStrategyIndex, Mode=TwoWay}" HorizontalAlignment="Stretch">
+                                <ComboBoxItem Content="{l:Loc NineRouterCombos_StrategyFallback}" />
+                                <ComboBoxItem Content="{l:Loc NineRouterCombos_StrategyRoundRobin}" />
+                                <ComboBoxItem Content="{l:Loc NineRouterCombos_StrategyFusion}" />
+                            </ComboBox>
+                            <StackPanel Spacing="4" IsVisible="{Binding IsDraftFusion}">
+                                <TextBlock Classes="row-desc" Text="{l:Loc NineRouterCombos_Judge}" />
+                                <ComboBox ItemsSource="{Binding AvailableModels}" SelectedItem="{Binding DraftJudgeModel, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                <TextBlock Classes="row-desc" Text="{l:Loc NineRouterCombos_JudgeAuto}" TextWrapping="Wrap" />
+                            </StackPanel>
+                        </StackPanel>
+
+                        <StackPanel Spacing="6">
+                            <TextBlock Classes="section-label" Text="{l:Loc NineRouterCombos_Models}" Margin="2,0" />
+                            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                                <ComboBox ItemsSource="{Binding AvailableModels}" SelectedItem="{Binding SelectedModel, Mode=TwoWay}" HorizontalAlignment="Stretch" />
+                                <Button Grid.Column="1" Classes="app" Content="{l:Loc NineRouterCombos_AddModel}"
+                                        Command="{Binding AddModelCommand}" IsEnabled="{Binding HasAvailableModels}" />
+                            </Grid>
+                            <TextBlock Classes="row-desc" Text="{l:Loc NineRouterCombos_NoModelsAvailable}"
+                                       IsVisible="{Binding !HasAvailableModels}" />
+
+                            <Border Classes="card" Padding="8" IsVisible="{Binding HasDraftModels}">
+                                <ItemsControl ItemsSource="{Binding DraftModels}">
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate>
+                                            <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="4" Margin="0,2">
+                                                <TextBlock Text="{Binding}" FontFamily="Cascadia Mono,Consolas,monospace"
+                                                           TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                                                <Button Grid.Column="1" Classes="icon-btn"
+                                                        Command="{Binding #Root.DataContext.NineRouterCombos.MoveDraftModelUpCommand}" CommandParameter="{Binding}">
+                                                    <lucide:PackIconLucide Kind="ChevronUp" Width="13" Height="13" Foreground="{DynamicResource FgMutedBrush}" />
+                                                </Button>
+                                                <Button Grid.Column="2" Classes="icon-btn"
+                                                        Command="{Binding #Root.DataContext.NineRouterCombos.MoveDraftModelDownCommand}" CommandParameter="{Binding}">
+                                                    <lucide:PackIconLucide Kind="ChevronDown" Width="13" Height="13" Foreground="{DynamicResource FgMutedBrush}" />
+                                                </Button>
+                                                <Button Grid.Column="3" Classes="icon-btn"
+                                                        Command="{Binding #Root.DataContext.NineRouterCombos.RemoveDraftModelCommand}" CommandParameter="{Binding}">
+                                                    <lucide:PackIconLucide Kind="X" Width="13" Height="13" Foreground="#D46A6A" />
+                                                </Button>
+                                            </Grid>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Border>
+                            <TextBlock Classes="row-desc" Text="{l:Loc NineRouterCombos_DraftEmpty}" Margin="2,0"
+                                       IsVisible="{Binding !HasDraftModels}" />
+                        </StackPanel>
+                    </StackPanel>
+                </ScrollViewer>
+
+                <Grid Grid.Row="3" RowDefinitions="Auto,Auto">
+                    <Border Grid.Row="0" Classes="row-divider" />
+                    <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" HorizontalAlignment="Right" Margin="18,12">
+                        <Button Classes="app" Content="{l:Loc Dialog_AddNineRouterKey_Cancel}"
+                                Command="{Binding #Root.DataContext.NineRouterCombos.CloseCreatePanelCommand}" />
+                        <Button Classes="app primary" Content="{l:Loc NineRouterCombos_Create}" IsVisible="{Binding !IsEditing}"
+                                IsEnabled="{Binding CanSubmit}" Command="{Binding SaveComboCommand}" />
+                        <Button Classes="app primary" Content="{l:Loc NineRouterCombos_Save}" IsVisible="{Binding IsEditing}"
+                                IsEnabled="{Binding CanSubmit}" Command="{Binding SaveComboCommand}" />
+                    </StackPanel>
+                </Grid>
+            </Grid>
+        </Border>
+    </Border>
+</UserControl>

--- a/src/TunnelAgent.Avalonia/Views/NineRouterComboOverlayView.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/NineRouterComboOverlayView.axaml.cs
@@ -1,0 +1,25 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using TunnelAgent.ViewModels;
+
+namespace TunnelAgent.Views;
+
+public partial class NineRouterComboOverlayView : UserControl
+{
+    public NineRouterComboOverlayView() => InitializeComponent();
+
+    private static void OnDialogCardPressed(object? sender, PointerPressedEventArgs e) => e.Handled = true;
+
+    private void OnOverlayPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel vm)
+            vm.NineRouterCombos.CloseCreatePanelCommand.Execute(null);
+    }
+
+    private void OnDialogKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.Escape || DataContext is not MainWindowViewModel vm) return;
+        e.Handled = true;
+        vm.NineRouterCombos.CloseCreatePanelCommand.Execute(null);
+    }
+}

--- a/src/TunnelAgent.Avalonia/Views/NineRouterCombosView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/NineRouterCombosView.axaml
@@ -1,0 +1,100 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:TunnelAgent.ViewModels"
+             xmlns:lucide="using:IconPacks.Avalonia.Lucide"
+             xmlns:l="using:TunnelAgent.Services"
+             x:Class="TunnelAgent.Views.NineRouterCombosView"
+             x:Name="Root"
+             x:DataType="vm:MainWindowViewModel">
+    <Grid>
+        <StackPanel Margin="0,0,0,24" Spacing="10" DataContext="{Binding NineRouterCombos}">
+            <StackPanel Margin="0,0,0,6">
+                <TextBlock Classes="page-title" Text="{l:Loc NineRouterCombos_Title}" />
+                <TextBlock Classes="page-sub" Text="{l:Loc NineRouterCombos_Subtitle}" />
+            </StackPanel>
+
+            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="8">
+                <TextBlock Classes="section-label" Text="{l:Loc NineRouterCombos_Title}" VerticalAlignment="Center" />
+                <Button Grid.Column="1" Classes="icon-btn" Command="{Binding RefreshCommand}" IsEnabled="{Binding IsEngineRunning}">
+                    <lucide:PackIconLucide Kind="RefreshCw" Width="14" Height="14" Foreground="{DynamicResource FgMutedBrush}" />
+                </Button>
+                <Button Grid.Column="2" Classes="icon-btn" ToolTip.Tip="{l:Loc NineRouterCombos_Create}"
+                        Command="{Binding OpenCreatePanelCommand}" IsEnabled="{Binding IsEngineRunning}">
+                    <lucide:PackIconLucide Kind="Plus" Width="15" Height="15" />
+                </Button>
+            </Grid>
+
+            <Border Background="#18F59E0B" BorderBrush="#44F59E0B" BorderThickness="1" CornerRadius="8" Padding="10"
+                    IsVisible="{Binding !IsEngineRunning}">
+                <StackPanel Spacing="4">
+                    <TextBlock Classes="row-label" Text="{l:Loc Fallback_AddModelPopup_ServerWarning_Title}" />
+                    <TextBlock Classes="row-desc" TextWrapping="Wrap" Text="{l:Loc NineRouterCombos_EngineNotRunning}" />
+                </StackPanel>
+            </Border>
+
+            <Border Background="#18D46A6A" BorderBrush="#44D46A6A" BorderThickness="1" CornerRadius="8" Padding="10"
+                    IsVisible="{Binding HasError}">
+                <TextBlock Classes="row-desc" Text="{Binding ErrorMessage}" TextWrapping="Wrap" />
+            </Border>
+
+            <StackPanel Spacing="8" IsVisible="{Binding IsEngineRunning}">
+                <TextBlock Classes="row-desc" Text="{l:Loc NineRouterCombos_Empty}" IsVisible="{Binding !HasCombos}" />
+                <ItemsControl ItemsSource="{Binding Combos}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                            <Border Classes="card" Margin="0,0,0,8">
+                                <StackPanel>
+                                    <Grid Margin="12,10" ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="8">
+                                        <ToggleButton Grid.Column="0" Classes="chevron" Width="22" Height="22" VerticalAlignment="Center"
+                                                      IsChecked="{Binding IsExpanded, Mode=TwoWay}">
+                                            <lucide:PackIconLucide Kind="ChevronRight" Width="14" Height="14"
+                                                                   HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                                   Foreground="{DynamicResource FgMutedBrush}" />
+                                        </ToggleButton>
+                                        <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="3">
+                                            <TextBlock Text="{Binding Name}" FontWeight="SemiBold" FontSize="13"
+                                                       FontFamily="Cascadia Mono,Consolas,monospace" TextTrimming="CharacterEllipsis" />
+                                            <TextBlock Classes="row-desc"
+                                                       Text="{l:LocFormat Key=NineRouterCombos_ModelCount, Path=ModelCount}" />
+                                        </StackPanel>
+                                        <Button Grid.Column="2" Classes="icon-btn" VerticalAlignment="Center"
+                                                ToolTip.Tip="{l:Loc NineRouterCombos_Edit}"
+                                                Command="{Binding #Root.DataContext.NineRouterCombos.OpenEditPanelCommand}" CommandParameter="{Binding}">
+                                            <lucide:PackIconLucide Kind="Pencil" Width="14" Height="14" Foreground="{DynamicResource FgMutedBrush}" />
+                                        </Button>
+                                        <Button Grid.Column="3" Classes="icon-btn" VerticalAlignment="Center"
+                                                Command="{Binding #Root.DataContext.NineRouterCombos.DeleteCommand}" CommandParameter="{Binding}">
+                                            <lucide:PackIconLucide Kind="Trash2" Width="14" Height="14" Foreground="#D46A6A" />
+                                        </Button>
+                                    </Grid>
+
+                                    <Border Classes="collapsible" Classes.expanded="{Binding IsExpanded}">
+                                        <StackPanel>
+                                            <Border Classes="row-divider" />
+                                            <ItemsControl ItemsSource="{Binding Models}" Margin="12,6,12,2">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <Grid ColumnDefinitions="26,*" ColumnSpacing="10" Margin="0,4">
+                                                            <Border Grid.Column="0" Width="22" Height="22" CornerRadius="999"
+                                                                    Background="#14000000" VerticalAlignment="Center">
+                                                                <TextBlock Text="{Binding Position}" FontSize="11" Foreground="{DynamicResource FgMutedBrush}"
+                                                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                            </Border>
+                                                            <TextBlock Grid.Column="1" Text="{Binding Name}" FontSize="12"
+                                                                       FontFamily="Cascadia Mono,Consolas,monospace"
+                                                                       TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                                                        </Grid>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                    </Border>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/TunnelAgent.Avalonia/Views/NineRouterCombosView.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/NineRouterCombosView.axaml.cs
@@ -1,0 +1,8 @@
+using Avalonia.Controls;
+
+namespace TunnelAgent.Views;
+
+public partial class NineRouterCombosView : UserControl
+{
+    public NineRouterCombosView() => InitializeComponent();
+}

--- a/src/TunnelAgent.Core/Models/Enums.cs
+++ b/src/TunnelAgent.Core/Models/Enums.cs
@@ -3,7 +3,7 @@ namespace TunnelAgent.ViewModels;
 
 public enum ServerState { Stopped, Starting, Running, Error }
 
-public enum SectionKey { Home, Providers, Quota, Fallback, Agents, Logs, Configuration, ConfigGeneral, ConfigCliProxy, ConfigPerplexity, ConfigNineRouter }
+public enum SectionKey { Home, Providers, Quota, Fallback, NineRouterCombos, Agents, Logs, Configuration, ConfigGeneral, ConfigCliProxy, ConfigPerplexity, ConfigNineRouter }
 
 /// <summary>Strategy for selecting which API key to use when multiple accounts are configured for a provider.</summary>
 public enum RoutingStrategy { RoundRobin, FillFirst }

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -106,7 +106,55 @@ public sealed class ApiClient : IDisposable
         return payload.Connections ?? [];
     }
 
-    /// <summary>Gets routing settings via <c>GET /api/settings</c>.</summary>
+    /// <summary>Lists model combos via <c>GET /api/combos</c>.</summary>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<IReadOnlyList<NineRouterCombo>> ListCombosAsync(CancellationToken ct = default)
+    {
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Get, "api/combos", body: null, ct)
+            .ConfigureAwait(false);
+        var payload = await ReadJsonAsync<ComboListResponse>(response, ct).ConfigureAwait(false);
+        return payload.Combos ?? [];
+    }
+
+    /// <summary>Creates a model combo via <c>POST /api/combos</c>.</summary>
+    /// <param name="request">Combo name and ordered models.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterCombo> CreateComboAsync(NineRouterCreateComboRequest request, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Post, "api/combos", request, ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterCombo>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Updates a model combo via <c>PUT /api/combos/{id}</c>.</summary>
+    /// <param name="id">Combo id.</param>
+    /// <param name="request">Replacement name and ordered models.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterCombo> UpdateComboAsync(
+        string id,
+        NineRouterUpdateComboRequest request,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        ArgumentNullException.ThrowIfNull(request);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Put, ComboPath(id), request, ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterCombo>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Deletes a model combo via <c>DELETE /api/combos/{id}</c>.</summary>
+    /// <param name="id">Combo id.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task DeleteComboAsync(string id, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Delete, ComboPath(id), body: null, ct)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Gets combo strategy settings via <c>GET /api/settings</c>.</summary>
     /// <param name="ct">Token used to cancel the request.</param>
     public async Task<NineRouterSettings> GetSettingsAsync(CancellationToken ct = default)
     {
@@ -124,6 +172,23 @@ public sealed class ApiClient : IDisposable
     {
         ArgumentNullException.ThrowIfNull(request);
         using var response = await SendWithAuthRetryAsync(HttpMethod.Patch, "api/settings", request, ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterSettings>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Updates combo strategy settings via <c>PATCH /api/settings</c>.</summary>
+    /// <param name="strategies">Complete per-combo strategy map.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterSettings> UpdateComboStrategiesAsync(
+        Dictionary<string, NineRouterComboStrategy> strategies,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(strategies);
+        using var response = await SendWithAuthRetryAsync(
+                HttpMethod.Patch,
+                "api/settings",
+                new NineRouterUpdateComboStrategiesRequest { ComboStrategies = strategies },
+                ct)
             .ConfigureAwait(false);
         return await ReadJsonAsync<NineRouterSettings>(response, ct).ConfigureAwait(false);
     }
@@ -574,6 +639,9 @@ public sealed class ApiClient : IDisposable
     private static string ProviderPath(string id) =>
         "api/providers/" + Uri.EscapeDataString(id);
 
+    private static string ComboPath(string id) =>
+        "api/combos/" + Uri.EscapeDataString(id);
+
     private static string OAuthPath(string providerId, string action) =>
         "api/oauth/" + Uri.EscapeDataString(providerId) + "/" + action;
 
@@ -608,6 +676,8 @@ public sealed class ApiClient : IDisposable
     private sealed record ProviderListResponse(List<NineRouterProvider>? Connections, string? Error);
 
     private sealed record ProviderEnvelope(NineRouterProvider? Connection, string? Error);
+
+    private sealed record ComboListResponse(List<NineRouterCombo>? Combos, string? Error);
 
     private sealed record ValidationResponse(bool Valid, string? Error);
 

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -84,11 +84,14 @@ public sealed record NineRouterProvider
     public JsonElement? ProviderSpecificData { get; init; }
 }
 
-/// <summary>9Router routing settings returned by <c>GET /api/settings</c>.</summary>
+/// <summary>9Router settings used to configure model-combo strategies.</summary>
 public sealed record NineRouterSettings
 {
     /// <summary>Gets per-provider routing overrides keyed by provider id.</summary>
     public Dictionary<string, NineRouterProviderStrategy> ProviderStrategies { get; init; } = [];
+
+    /// <summary>Gets the per-combo strategy overrides keyed by combo name.</summary>
+    public Dictionary<string, NineRouterComboStrategy> ComboStrategies { get; init; } = [];
 }
 
 /// <summary>Routing override for one 9Router provider.</summary>
@@ -105,11 +108,68 @@ public sealed record NineRouterProviderStrategy
     public Dictionary<string, JsonElement>? AdditionalData { get; init; }
 }
 
+/// <summary>Strategy override for one 9Router combo.</summary>
+public sealed record NineRouterComboStrategy
+{
+    /// <summary>Gets the routing strategy, such as <c>fallback</c>, <c>round-robin</c>, or <c>fusion</c>.</summary>
+    public string? FallbackStrategy { get; init; }
+
+    /// <summary>Gets the optional model used to judge Fusion panel responses.</summary>
+    public string? JudgeModel { get; init; }
+
+    /// <summary>Gets settings that Tunnel Agent does not manage.</summary>
+    [JsonExtensionData]
+    public Dictionary<string, JsonElement>? AdditionalData { get; init; }
+}
+
+/// <summary>A model combo returned by <c>GET /api/combos</c>.</summary>
+public sealed record NineRouterCombo
+{
+    /// <summary>Gets the combo id.</summary>
+    public string? Id { get; init; }
+
+    /// <summary>Gets the name exposed to clients as a model.</summary>
+    public string? Name { get; init; }
+
+    /// <summary>Gets the ordered model fallback chain.</summary>
+    public List<string>? Models { get; init; }
+
+    /// <summary>Gets the optional combo type reported by 9Router.</summary>
+    public string? Kind { get; init; }
+}
+
+/// <summary>Body for <c>POST /api/combos</c>.</summary>
+public sealed record NineRouterCreateComboRequest
+{
+    /// <summary>Gets the combo name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the ordered models in the combo.</summary>
+    public required List<string> Models { get; init; }
+}
+
+/// <summary>Body for <c>PUT /api/combos/{id}</c>.</summary>
+public sealed record NineRouterUpdateComboRequest
+{
+    /// <summary>Gets the replacement combo name.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the replacement ordered models.</summary>
+    public required List<string> Models { get; init; }
+}
+
 /// <summary>Body for <c>PATCH /api/settings</c> when replacing provider routing overrides.</summary>
 public sealed record NineRouterUpdateSettingsRequest
 {
     /// <summary>Gets the complete per-provider routing-override map.</summary>
     public required Dictionary<string, NineRouterProviderStrategy> ProviderStrategies { get; init; }
+}
+
+/// <summary>Body for <c>PATCH /api/settings</c> when replacing combo strategies.</summary>
+public sealed record NineRouterUpdateComboStrategiesRequest
+{
+    /// <summary>Gets the complete per-combo strategy map.</summary>
+    public required Dictionary<string, NineRouterComboStrategy> ComboStrategies { get; init; }
 }
 
 /// <summary>

--- a/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
@@ -93,6 +93,45 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
+    public void NineRouterComboDialog_RequiresRunningEngine()
+    {
+        var running = false;
+        var combos = new NineRouterCombosViewModel(
+            () => 8317,
+            () => running,
+            new System.Collections.ObjectModel.ObservableCollection<AvailableModelGroupViewModel>());
+
+        combos.OpenCreatePanelCommand.Execute(null);
+        Assert.False(combos.ShowCreatePanel);
+
+        running = true;
+        combos.OpenCreatePanelCommand.Execute(null);
+        Assert.True(combos.ShowCreatePanel);
+
+        running = false;
+        combos.NotifyEngineStateChanged();
+        Assert.False(combos.ShowCreatePanel);
+    }
+
+    [Fact]
+    public void FallbackSubmenu_TogglesAndSelectsBothViews()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.ToggleFallbackSubmenuCommand.Execute(null);
+        Assert.True(vm.IsFallbackSubmenuExpanded);
+
+        vm.SelectFallbackCommand.Execute(null);
+        Assert.Equal(SectionKey.Fallback, vm.SelectedSection);
+
+        vm.SelectNineRouterCombosCommand.Execute(null);
+        Assert.Equal(SectionKey.NineRouterCombos, vm.SelectedSection);
+
+        vm.ToggleFallbackSubmenuCommand.Execute(null);
+        Assert.False(vm.IsFallbackSubmenuExpanded);
+    }
+
+    [Fact]
     public void NineRouterProviderPagination_FiltersAndNavigatesCatalog()
     {
         var vm = new MainWindowViewModel();

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -88,6 +88,78 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
+    public async Task CombosAsync_UsesManagementEndpoints()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "combos": [{ "id": "combo-1", "name": "coding", "models": ["cc/claude-opus-5", "cc/claude-sonnet-5"] }] }
+            """);
+        handler.EnqueueJson(HttpStatusCode.Created, """
+            { "id": "combo-2", "name": "backup", "models": ["openai/gpt-5"] }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "success": true }""");
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "comboStrategies": {} }""");
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "comboStrategies": { "coding": { "fallbackStrategy": "fusion", "judgeModel": "openai/gpt-5" } } }""");
+        using var client = new ApiClient(Port, handler);
+
+        var combos = await client.ListCombosAsync();
+        var created = await client.CreateComboAsync(new NineRouterCreateComboRequest
+        {
+            Name = "backup",
+            Models = ["openai/gpt-5"]
+        });
+        await client.DeleteComboAsync("combo-2");
+        var settings = await client.GetSettingsAsync();
+        var updated = await client.UpdateComboStrategiesAsync(new Dictionary<string, NineRouterComboStrategy>
+        {
+            ["coding"] = new() { FallbackStrategy = "fusion", JudgeModel = "openai/gpt-5" }
+        });
+
+        Assert.Single(combos);
+        Assert.Equal("coding", combos[0].Name);
+        Assert.Equal("combo-2", created.Id);
+        Assert.Empty(settings.ComboStrategies);
+        Assert.Equal("fusion", updated.ComboStrategies["coding"].FallbackStrategy);
+        Assert.Equal("openai/gpt-5", updated.ComboStrategies["coding"].JudgeModel);
+        Assert.Equal("GET", handler.Requests[0].Method);
+        Assert.Equal("/api/combos", handler.Requests[0].Path);
+        Assert.Equal("POST", handler.Requests[1].Method);
+        Assert.Equal("DELETE", handler.Requests[2].Method);
+        Assert.Equal("/api/combos/combo-2", handler.Requests[2].Path);
+        Assert.Equal("PATCH", handler.Requests[4].Method);
+        using var createBody = JsonDocument.Parse(handler.Requests[1].Body!);
+        Assert.Equal("backup", createBody.RootElement.GetProperty("name").GetString());
+        Assert.Equal("openai/gpt-5", createBody.RootElement.GetProperty("models")[0].GetString());
+        using var settingsBody = JsonDocument.Parse(handler.Requests[4].Body!);
+        var strategyBody = settingsBody.RootElement.GetProperty("comboStrategies").GetProperty("coding");
+        Assert.Equal("fusion", strategyBody.GetProperty("fallbackStrategy").GetString());
+        Assert.Equal("openai/gpt-5", strategyBody.GetProperty("judgeModel").GetString());
+    }
+
+    [Fact]
+    public async Task UpdateComboAsync_PutsReplacementNameAndModels()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            { "id": "combo-1", "name": "coding-v2", "models": ["openai/gpt-5"] }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var updated = await client.UpdateComboAsync("combo-1", new NineRouterUpdateComboRequest
+        {
+            Name = "coding-v2",
+            Models = ["openai/gpt-5"]
+        });
+
+        Assert.Equal("coding-v2", updated.Name);
+        Assert.Equal("PUT", handler.Requests[0].Method);
+        Assert.Equal("/api/combos/combo-1", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.Equal("coding-v2", body.RootElement.GetProperty("name").GetString());
+        Assert.Equal("openai/gpt-5", body.RootElement.GetProperty("models")[0].GetString());
+    }
+
+    [Fact]
     public async Task CreateProviderAsync_PostsCamelCaseBody_Returns201Connection()
     {
         using var handler = new FakeApiHandler();
@@ -149,23 +221,21 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
-    public async Task UpdateProviderAsync_PutsSuppliedFields_ReturnsUpdatedConnection()
+    public async Task UpdateProviderAsync_PutsIsActive_ReturnsUpdatedConnection()
     {
         using var handler = new FakeApiHandler();
         handler.EnqueueJson(HttpStatusCode.OK, """
-            { "connection": { "id": "conn-1", "provider": "openai", "name": "Personal", "isActive": false } }
+            { "connection": { "id": "conn-1", "provider": "openai", "name": "OpenAI", "isActive": false } }
             """);
         using var client = new ApiClient(Port, handler);
 
-        var updated = await client.UpdateProviderAsync("conn-1", new NineRouterUpdateProviderRequest { Name = "Personal", IsActive = false });
+        var updated = await client.UpdateProviderAsync("conn-1", new NineRouterUpdateProviderRequest { IsActive = false });
 
         Assert.Equal("conn-1", updated.Id);
-        Assert.Equal("Personal", updated.Name);
         Assert.False(updated.IsActive);
         Assert.Equal("PUT", handler.Requests[0].Method);
         Assert.Equal("/api/providers/conn-1", handler.Requests[0].Path);
         using var body = JsonDocument.Parse(handler.Requests[0].Body!);
-        Assert.Equal("Personal", body.RootElement.GetProperty("name").GetString());
         Assert.False(body.RootElement.GetProperty("isActive").GetBoolean());
         Assert.False(body.RootElement.TryGetProperty("apiKey", out _));
     }


### PR DESCRIPTION
## Summary
- add a dedicated 9Router Combos view and nested Fallback navigation
- manage combo creation, editing, ordering, strategies, and Fusion judges
- show the 9Router-running state and use an app-wide combo dialog

## Tests
-   TunnelAgent.Abstractions -> C:\Users\mikel\development\personal\projects\tunnel-agent\repositories\tunnel-agent\src\TunnelAgent.Abstractions\bin\Debug\net10.0\TunnelAgent.Abstractions.dll
  TunnelAgent.Core -> C:\Users\mikel\development\personal\projects\tunnel-agent\repositories\tunnel-agent\src\TunnelAgent.Core\bin\Debug\net10.0\TunnelAgent.Core.dll
  TunnelAgent.Infrastructure -> C:\Users\mikel\development\personal\projects\tunnel-agent\repositories\tunnel-agent\src\TunnelAgent.Infrastructure\bin\Debug\net10.0\TunnelAgent.Infrastructure.dll
  TunnelAgent.Avalonia -> C:\Users\mikel\development\personal\projects\tunnel-agent\repositories\tunnel-agent\src\TunnelAgent.Avalonia\bin\Debug\net10.0\TunnelAgent.dll
  TunnelAgent.Tests -> C:\Users\mikel\development\personal\projects\tunnel-agent\repositories\tunnel-agent\tests\TunnelAgent.Tests\bin\Debug\net10.0\TunnelAgent.Tests.dll
Test run for C:\Users\mikel\development\personal\projects\tunnel-agent\repositories\tunnel-agent\tests\TunnelAgent.Tests\bin\Debug\net10.0\TunnelAgent.Tests.dll (.NETCoreApp,Version=v10.0)
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:    46, Skipped:     0, Total:    46, Duration: 6 s - TunnelAgent.Tests.dll (net10.0)