### PR TITLE
Add 9Router quota usage view

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -906,6 +906,27 @@
   <data name="QuotaView_Subtitle" xml:space="preserve">
     <value>Track quota usage for supported CLIProxyAPI accounts.</value>
   </data>
+  <data name="Sidebar_NineRouterUsage" xml:space="preserve">
+    <value>9Router Usage</value>
+  </data>
+  <data name="QuotaView_NineRouterUsage_Title" xml:space="preserve">
+    <value>9Router Usage</value>
+  </data>
+  <data name="QuotaView_NineRouterUsage_Subtitle" xml:space="preserve">
+    <value>Track quota limits for connections managed by 9Router.</value>
+  </data>
+  <data name="QuotaView_NineRouterUsage_RefreshAllTooltip" xml:space="preserve">
+    <value>Refresh all 9Router usage</value>
+  </data>
+  <data name="QuotaView_NineRouterUsage_RefreshTooltip" xml:space="preserve">
+    <value>Refresh usage</value>
+  </data>
+  <data name="QuotaView_NineRouterUsage_EngineNotRunning" xml:space="preserve">
+    <value>Start 9Router to view connection usage.</value>
+  </data>
+  <data name="QuotaView_NineRouterUsage_NoAccountsDescription" xml:space="preserve">
+    <value>Connect an account in 9Router to view its usage limits.</value>
+  </data>
   <data name="QuotaView_RefreshAllTooltip" xml:space="preserve">
     <value>Refresh all quota providers</value>
   </data>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -160,15 +160,25 @@ SelectedSection is SectionKey.Logs;
         }
     }
 
-    [ObservableProperty] private SectionKey _selectedSection = SectionKey.Home;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsQuotaLimitsActive))]
+    [NotifyPropertyChangedFor(nameof(IsQuotaUsageActive))]
+    private SectionKey _selectedSection = SectionKey.Home;
     [ObservableProperty] private bool _isSidebarCollapsed;
+    [ObservableProperty] private bool _isQuotaSubmenuExpanded;
     [ObservableProperty] private bool _isFallbackSubmenuExpanded;
     [ObservableProperty] private bool _isDark;
     [ObservableProperty] private string _focusedConfigEngineId = EngineCatalog.CliProxyApi.Id;
     [ObservableProperty] private string _providersEngineId = EngineCatalog.CliProxyApi.Id;
     [ObservableProperty] private ProviderViewModel? _selectedQuotaProvider;
     [ObservableProperty] private QuotaProviderViewModel? _selectedQuotaAccount;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsQuotaLimitsSelected))]
+    [NotifyPropertyChangedFor(nameof(IsQuotaLimitsActive))]
+    [NotifyPropertyChangedFor(nameof(IsQuotaUsageActive))]
+    private bool _isQuotaUsageSelected;
     [ObservableProperty] private bool _isRefreshingAllQuotaProviders;
+    [ObservableProperty] private bool _isRefreshingNineRouterUsage;
 
     [ObservableProperty] private EngineState _engineState = EngineState.Stopped;
     [ObservableProperty] private string? _installedVersion;
@@ -538,6 +548,12 @@ SelectedSection is SectionKey.Logs;
         SectionKey.ConfigPerplexity => 3,
         _ => 0
     };
+    public bool IsQuotaLimitsSelected => !IsQuotaUsageSelected;
+    public bool IsQuotaLimitsActive => SelectedSection == SectionKey.Quota && IsQuotaLimitsSelected;
+    public bool IsQuotaUsageActive => SelectedSection == SectionKey.Quota && IsQuotaUsageSelected;
+    public bool HasNineRouterUsageConnections => NineRouterConnections.Count > 0;
+    public bool ShowNineRouterUsageEmptyState => IsNineRouterEngineRunning && !HasNineRouterUsageConnections;
+
     public int QuotaTabIndex =>
         (SelectedQuotaAccount?.Id ?? SelectedQuotaProvider?.Id) switch
         {
@@ -968,7 +984,7 @@ SelectedSection is SectionKey.Logs;
         if (value == SectionKey.Quota)
         {
             RefreshQuotaNavigation();
-            _ = ScanAndRefreshQuotaOnceAsync();
+            _ = IsQuotaUsageSelected ? RefreshNineRouterUsageAsync() : ScanAndRefreshQuotaOnceAsync();
         }
         else if (value == SectionKey.Agents && !_agentsDetectedOnce)
         {
@@ -1417,6 +1433,8 @@ SelectedSection is SectionKey.Logs;
                         _allNineRouterProviders.Clear();
                         NineRouterProviderPageNavigationItems.Clear();
                         OnPropertyChanged(nameof(HasNineRouterConnections));
+                        OnPropertyChanged(nameof(HasNineRouterUsageConnections));
+                        OnPropertyChanged(nameof(ShowNineRouterUsageEmptyState));
                     }
                     modelGroups?.Clear();
                     if (isCliProxy)
@@ -1477,6 +1495,7 @@ SelectedSection is SectionKey.Logs;
             }
 
             RefreshEngineSectionProperties();
+            OnPropertyChanged(nameof(ShowNineRouterUsageEmptyState));
         });
     }
 
@@ -2972,6 +2991,8 @@ SelectedSection is SectionKey.Logs;
                 _allNineRouterProviders.Clear();
                 NineRouterProviderPageNavigationItems.Clear();
                 OnPropertyChanged(nameof(HasNineRouterConnections));
+                OnPropertyChanged(nameof(HasNineRouterUsageConnections));
+                OnPropertyChanged(nameof(ShowNineRouterUsageEmptyState));
             });
             return;
         }
@@ -3041,6 +3062,56 @@ SelectedSection is SectionKey.Logs;
         NineRouterProviderCurrentPage = 1;
         ApplyNineRouterProviderFilter();
         OnPropertyChanged(nameof(HasNineRouterConnections));
+        OnPropertyChanged(nameof(HasNineRouterUsageConnections));
+        OnPropertyChanged(nameof(ShowNineRouterUsageEmptyState));
+    }
+
+    private async Task RefreshNineRouterUsageAsync()
+    {
+        if (IsRefreshingNineRouterUsage || NineRouterEngine.State != EngineState.Running) return;
+
+        IsRefreshingNineRouterUsage = true;
+        try
+        {
+            await RefreshNineRouterConnectionsAsync();
+            using var client = new ApiClient(NineRouterEngine.Port);
+            foreach (var connection in NineRouterConnections)
+                await RefreshNineRouterUsageAsync(connection, client);
+        }
+        finally
+        {
+            IsRefreshingNineRouterUsage = false;
+        }
+    }
+
+    public async Task RefreshNineRouterUsageAsync(NineRouterConnectionViewModel connection)
+    {
+        ArgumentNullException.ThrowIfNull(connection);
+        if (NineRouterEngine.State != EngineState.Running || connection.IsUsageRefreshing) return;
+
+        using var client = new ApiClient(NineRouterEngine.Port);
+        await RefreshNineRouterUsageAsync(connection, client);
+    }
+
+    private static async Task RefreshNineRouterUsageAsync(
+        NineRouterConnectionViewModel connection,
+        ApiClient client)
+    {
+        if (connection.IsUsageRefreshing) return;
+
+        connection.IsUsageRefreshing = true;
+        try
+        {
+            connection.ApplyUsage(await client.GetUsageAsync(connection.Id, force: true));
+        }
+        catch (Exception ex)
+        {
+            connection.SetUsageError(ex.Message);
+        }
+        finally
+        {
+            connection.IsUsageRefreshing = false;
+        }
     }
 
     [RelayCommand]
@@ -3390,8 +3461,30 @@ SelectedSection is SectionKey.Logs;
     [RelayCommand]
     private void SelectQuota()
     {
+        IsQuotaSubmenuExpanded = true;
+        IsQuotaUsageSelected = false;
         SelectedSection = SectionKey.Quota;
         FocusedConfigEngineId = EngineCatalog.CliProxyApi.Id;
+    }
+
+    [RelayCommand]
+    private void ToggleQuotaSubmenu() => IsQuotaSubmenuExpanded = !IsQuotaSubmenuExpanded;
+
+    [RelayCommand]
+    private void SelectQuotaLimits()
+    {
+        IsQuotaSubmenuExpanded = true;
+        IsQuotaUsageSelected = false;
+        SelectedSection = SectionKey.Quota;
+    }
+
+    [RelayCommand]
+    private async Task SelectQuotaUsageAsync()
+    {
+        IsQuotaSubmenuExpanded = true;
+        IsQuotaUsageSelected = true;
+        SelectedSection = SectionKey.Quota;
+        await RefreshNineRouterUsageAsync();
     }
 
     /// <summary>True when the tray usage popup is showing the Home view (engines + aggregated usage) instead of a single provider's quota.</summary>

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterConnectionViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterConnectionViewModel.cs
@@ -1,4 +1,8 @@
+using System;
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using IconPacks.Avalonia.SimpleIcons;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
 using TunnelAgent.Services;
 
 namespace TunnelAgent.ViewModels;
@@ -6,7 +10,7 @@ namespace TunnelAgent.ViewModels;
 /// <summary>
 /// One 9Router provider connection shown on the Providers tab.
 /// </summary>
-public sealed class NineRouterConnectionViewModel
+public sealed partial class NineRouterConnectionViewModel : ObservableObject
 {
     /// <summary>Creates a row from a management-API connection.</summary>
     /// <param name="id">Connection id used for update/delete.</param>
@@ -35,6 +39,8 @@ public sealed class NineRouterConnectionViewModel
         CustomIconData = icon.CustomIconData;
         UseMonogram = icon.UseMonogram;
         Monogram = icon.Monogram;
+        UsageBars.CollectionChanged += (_, _) => OnPropertyChanged(nameof(HasUsage));
+        LocalizationService.Instance.PropertyChanged += (_, _) => OnPropertyChanged(nameof(UsageEmptyDescription));
     }
 
     /// <summary>Gets the connection id.</summary>
@@ -81,4 +87,89 @@ public sealed class NineRouterConnectionViewModel
 
     /// <summary>Gets whether <see cref="AuthType"/> should be shown.</summary>
     public bool HasAuthType => !string.IsNullOrWhiteSpace(AuthType);
+
+    /// <summary>Gets the provider plan returned with usage, if any.</summary>
+    [ObservableProperty] private string _planBadge = "";
+
+    /// <summary>Gets the current usage windows.</summary>
+    public ObservableCollection<QuotaBarViewModel> UsageBars { get; } = [];
+
+    /// <summary>Gets whether any usage window was returned.</summary>
+    public bool HasUsage => UsageBars.Count > 0;
+
+    /// <summary>Gets the last usage error or unavailable message.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UsageEmptyDescription))]
+    private string _usageError = "";
+
+    /// <summary>Gets whether 9Router successfully returned no usage windows.</summary>
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(UsageEmptyDescription))]
+    private bool _usageFetchedEmpty;
+
+    /// <summary>Gets whether this connection's usage is being refreshed.</summary>
+    [ObservableProperty] private bool _isUsageRefreshing;
+
+    /// <summary>Gets the no-data description displayed below the connection.</summary>
+    public string UsageEmptyDescription => !string.IsNullOrWhiteSpace(UsageError)
+        ? UsageError
+        : UsageFetchedEmpty
+            ? LocalizationService.Instance.GetString("Quota_Empty_NoDataDescription")
+            : LocalizationService.Instance.GetString("Quota_Empty_NotLoadedDescription");
+
+    /// <summary>Applies a normalized response from 9Router's usage API.</summary>
+    public void ApplyUsage(NineRouterUsage usage)
+    {
+        ArgumentNullException.ThrowIfNull(usage);
+        PlanBadge = usage.Plan ?? "";
+        UsageError = usage.Message ?? "";
+        UsageBars.Clear();
+
+        foreach (var (name, quota) in usage.Quotas ?? [])
+        {
+            var used = UsedFraction(quota);
+            if (used is null) continue;
+            UsageBars.Add(new QuotaBarViewModel
+            {
+                Title = quota.DisplayName ?? name,
+                Used = used.Value,
+                ResetIn = ResetIn(quota.ResetAt)
+            });
+        }
+
+        UsageFetchedEmpty = UsageBars.Count == 0 && string.IsNullOrWhiteSpace(UsageError);
+    }
+
+    /// <summary>Records a failed usage fetch without discarding the last successful values.</summary>
+    public void SetUsageError(string error)
+    {
+        UsageError = error;
+        UsageFetchedEmpty = false;
+    }
+
+    private static double? UsedFraction(NineRouterUsageQuota quota)
+    {
+        if (quota.RemainingPercentage is { } remainingPercentage)
+            return Math.Clamp(1 - remainingPercentage / 100, 0, 1);
+        if (quota.Total is > 0)
+        {
+            if (quota.Used is { } used)
+                return Math.Clamp(used / quota.Total.Value, 0, 1);
+            if (quota.Remaining is { } remaining)
+                return Math.Clamp(1 - remaining / quota.Total.Value, 0, 1);
+        }
+        if (quota.Remaining is { } percentage and >= 0 and <= 100)
+            return Math.Clamp(1 - percentage / 100, 0, 1);
+        return null;
+    }
+
+    private static string ResetIn(string? resetAt)
+    {
+        if (!DateTimeOffset.TryParse(resetAt, out var at)) return "";
+        var diff = at - DateTimeOffset.UtcNow;
+        if (diff <= TimeSpan.Zero) return "loc:Quota_ResetInNow";
+        if (diff.TotalDays >= 1) return $"loc:Quota_ResetInDaysHours|{(int)diff.TotalDays}|{diff.Hours}";
+        if (diff.TotalHours >= 1) return $"loc:Quota_ResetInHoursMinutes|{(int)diff.TotalHours}|{diff.Minutes}";
+        return $"loc:Quota_ResetInMinutes|{diff.Minutes}";
+    }
 }

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -194,27 +194,34 @@
                                 </Grid>
                             </Button>
 
-                            <Button Classes="side" Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Quota}"
-                                    Command="{Binding SelectQuotaCommand}">
-                                <Grid ColumnDefinitions="20,*,Auto">
-                                    <lucide:PackIconLucide Grid.Column="0" Kind="ChartBar" Width="15" Height="15"
-                                                           HorizontalAlignment="Center" VerticalAlignment="Center" />
-                                    <Panel Grid.Column="1" Grid.ColumnSpan="2"
-                                           Opacity="{Binding SidebarContentOpacity}">
-                                        <Panel.Transitions>
-                                            <Transitions>
-                                                <DoubleTransition Property="Opacity" Duration="0:0:0.18" Easing="CubicEaseInOut" />
-                                            </Transitions>
-                                        </Panel.Transitions>
-                                        <TextBlock Text="{l:Loc Sidebar_Quota}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
-                                                   IsVisible="{Binding !IsSidebarCollapsed}"/>
-                                        <Border HorizontalAlignment="Right" CornerRadius="999" Background="#14000000" Padding="6,1"
-                                                IsVisible="{Binding !IsSidebarCollapsed}">
-                                            <TextBlock Text="{Binding QuotaProviderCount}" FontSize="11" />
-                                        </Border>
-                                    </Panel>
-                                </Grid>
-                            </Button>
+                            <StackPanel Spacing="2">
+                                <Button Classes="side" Command="{Binding ToggleQuotaSubmenuCommand}">
+                                    <Grid ColumnDefinitions="20,*,Auto">
+                                        <lucide:PackIconLucide Grid.Column="0" Kind="ChartBar" Width="15" Height="15"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                        <TextBlock Grid.Column="1" Text="{l:Loc Sidebar_Quota}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
+                                                   Opacity="{Binding SidebarContentOpacity}" IsVisible="{Binding !IsSidebarCollapsed}" />
+                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center" IsVisible="{Binding !IsSidebarCollapsed}">
+                                            <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
+                                                                    IsVisible="{Binding IsQuotaSubmenuExpanded, Converter={StaticResource InvertBool}}" />
+                                            <lucide:PackIconLucide Kind="ChevronDown" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
+                                                                    IsVisible="{Binding IsQuotaSubmenuExpanded}" />
+                                        </Panel>
+                                    </Grid>
+                                </Button>
+                                <StackPanel Spacing="2" Margin="18,0,0,0" IsVisible="{Binding IsQuotaSubmenuExpanded}">
+                                    <Button Classes="side side-sub" Classes.selected="{Binding IsQuotaLimitsActive}"
+                                            Command="{Binding SelectQuotaLimitsCommand}">
+                                        <TextBlock Text="{l:Loc Sidebar_Quota}" FontSize="11" Margin="0"
+                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                    </Button>
+                                    <Button Classes="side side-sub" Classes.selected="{Binding IsQuotaUsageActive}"
+                                            Command="{Binding SelectQuotaUsageCommand}">
+                                        <TextBlock Text="{l:Loc Sidebar_NineRouterUsage}" FontSize="11" Margin="0"
+                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                    </Button>
+                                </StackPanel>
+                            </StackPanel>
 
                             <StackPanel Spacing="2">
                                 <Button Classes="side" Command="{Binding ToggleFallbackSubmenuCommand}">

--- a/src/TunnelAgent.Avalonia/Views/QuotaView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/QuotaView.axaml
@@ -14,6 +14,7 @@
     </UserControl.Resources>
 
     <StackPanel Spacing="0" Margin="0,0,0,24">
+        <StackPanel Spacing="0" IsVisible="{Binding IsQuotaLimitsSelected}">
         <ctrl:SlidingTabBar Margin="0,0,0,16"
                             SelectedIndex="{Binding QuotaTabIndex}">
             <ctrl:SlidingTabBar.Tabs>
@@ -193,5 +194,130 @@
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
+        </StackPanel>
+
+        <StackPanel Spacing="0" IsVisible="{Binding IsQuotaUsageSelected}">
+            <Grid Margin="0,0,0,16" ColumnDefinitions="*,Auto">
+                <StackPanel>
+                    <TextBlock Classes="page-title" Text="{l:Loc QuotaView_NineRouterUsage_Title}" />
+                    <TextBlock Classes="page-sub" Text="{l:Loc QuotaView_NineRouterUsage_Subtitle}" />
+                </StackPanel>
+                <Button Grid.Column="1"
+                        Classes="icon"
+                        ToolTip.Tip="{l:Loc QuotaView_NineRouterUsage_RefreshAllTooltip}"
+                        VerticalAlignment="Bottom"
+                        IsEnabled="{Binding IsNineRouterEngineRunning}"
+                        Click="OnRefreshAllNineRouterUsage">
+                    <lucide:PackIconLucide Kind="RefreshCw"
+                                           Width="14"
+                                           Height="14"
+                                           Classes.spin="{Binding IsRefreshingNineRouterUsage}" />
+                </Button>
+            </Grid>
+
+            <Border Background="#18F59E0B" BorderBrush="#44F59E0B" BorderThickness="1" CornerRadius="8" Padding="10"
+                    IsVisible="{Binding IsNineRouterEngineRunning, Converter={StaticResource InvertBool}}">
+                <StackPanel Spacing="4">
+                    <TextBlock Classes="row-label" Text="{l:Loc Fallback_AddModelPopup_ServerWarning_Title}" />
+                    <TextBlock Classes="row-desc" TextWrapping="Wrap"
+                               Text="{l:Loc QuotaView_NineRouterUsage_EngineNotRunning}" />
+                </StackPanel>
+            </Border>
+
+            <Border Classes="card" Padding="22"
+                    IsVisible="{Binding ShowNineRouterUsageEmptyState}">
+                <StackPanel Spacing="8" HorizontalAlignment="Center">
+                    <lucide:PackIconLucide Kind="UserRoundX"
+                                           Width="30"
+                                           Height="30"
+                                           Foreground="{DynamicResource FgFaintBrush}"
+                                           HorizontalAlignment="Center" />
+                    <TextBlock Classes="row-label" Text="{l:Loc QuotaView_NoAccounts_Title}" HorizontalAlignment="Center" />
+                    <TextBlock Classes="row-desc"
+                               Text="{l:Loc QuotaView_NineRouterUsage_NoAccountsDescription}"
+                               TextAlignment="Center"
+                               TextWrapping="Wrap"
+                               MaxWidth="420" />
+                </StackPanel>
+            </Border>
+
+            <ItemsControl ItemsSource="{Binding NineRouterConnections}"
+                          IsVisible="{Binding HasNineRouterUsageConnections}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:NineRouterConnectionViewModel">
+                        <Border Classes="card" Padding="16" Margin="0,0,0,14">
+                            <StackPanel Spacing="14">
+                                <Grid ColumnDefinitions="*,Auto">
+                                    <StackPanel Grid.Column="0" Spacing="2">
+                                        <StackPanel Orientation="Horizontal" Spacing="8">
+                                            <TextBlock Text="{Binding Name}"
+                                                       FontSize="14"
+                                                       FontWeight="SemiBold"
+                                                       Foreground="{DynamicResource FgBrush}" />
+                                            <Border Classes="chip"
+                                                    Background="{DynamicResource AccentSoftBrush}"
+                                                    IsVisible="{Binding PlanBadge, Converter={StaticResource StringNotEmpty}}">
+                                                <TextBlock Text="{Binding PlanBadge}"
+                                                           Foreground="{DynamicResource AccentBrush}"
+                                                           FontWeight="Bold" />
+                                            </Border>
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding ProviderId}"
+                                                   FontFamily="Cascadia Mono,Consolas,monospace"
+                                                   FontSize="11"
+                                                   Foreground="{DynamicResource FgMutedBrush}" />
+                                    </StackPanel>
+                                    <Button Grid.Column="1"
+                                            Classes="icon"
+                                            ToolTip.Tip="{l:Loc QuotaView_NineRouterUsage_RefreshTooltip}"
+                                            Click="OnRefreshNineRouterUsage"
+                                            Tag="{Binding}">
+                                        <lucide:PackIconLucide Kind="RefreshCw"
+                                                               Width="14"
+                                                               Height="14"
+                                                               Classes.spin="{Binding IsUsageRefreshing}" />
+                                    </Button>
+                                </Grid>
+
+                                <TextBlock Text="{Binding UsageError}"
+                                           Classes="row-desc"
+                                           Foreground="{DynamicResource ErrBrush}"
+                                           TextWrapping="Wrap"
+                                           IsVisible="{Binding UsageError, Converter={StaticResource StringNotEmpty}}" />
+
+                                <StackPanel Spacing="10" IsVisible="{Binding HasUsage}">
+                                    <TextBlock Classes="section-label" Text="{l:Loc QuotaView_Account_UsageSection}" Margin="0" />
+                                    <ItemsControl ItemsSource="{Binding UsageBars}">
+                                        <ItemsControl.ItemTemplate>
+                                            <DataTemplate x:DataType="vm:QuotaBarViewModel">
+                                                <StackPanel Spacing="5" Margin="0,0,0,10">
+                                                    <Grid ColumnDefinitions="*,Auto">
+                                                        <TextBlock Grid.Column="0" Text="{Binding Title}"
+                                                                   FontSize="12" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource FgBrush}" />
+                                                        <TextBlock Grid.Column="1" Text="{Binding UsedLabel}"
+                                                                   FontSize="12" FontWeight="SemiBold"
+                                                                   Foreground="{DynamicResource AccentBrush}" />
+                                                    </Grid>
+                                                    <ProgressBar Minimum="0" Maximum="1" Value="{Binding Used}" Height="9" />
+                                                    <TextBlock Text="{Binding ResetIn}" FontSize="10.5"
+                                                               Foreground="{DynamicResource FgFaintBrush}"
+                                                               IsVisible="{Binding ResetIn, Converter={StaticResource StringNotEmpty}}" />
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ItemsControl.ItemTemplate>
+                                    </ItemsControl>
+                                </StackPanel>
+
+                                <Border Background="#08FFFFFF" CornerRadius="8" Padding="14"
+                                        IsVisible="{Binding HasUsage, Converter={StaticResource InvertBool}}">
+                                    <TextBlock Classes="row-desc" Text="{Binding UsageEmptyDescription}" TextWrapping="Wrap" />
+                                </Border>
+                            </StackPanel>
+                        </Border>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/TunnelAgent.Avalonia/Views/QuotaView.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/QuotaView.axaml.cs
@@ -32,4 +32,17 @@ public partial class QuotaView : UserControl
             Dispatcher.UIThread.Post(() => account.IsRefreshing = false);
         }
     }
+
+    private async void OnRefreshAllNineRouterUsage(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is MainWindowViewModel vm)
+            await vm.SelectQuotaUsageCommand.ExecuteAsync(null);
+    }
+
+    private async void OnRefreshNineRouterUsage(object? sender, RoutedEventArgs e)
+    {
+        if (DataContext is not MainWindowViewModel vm) return;
+        if (sender is not Button { Tag: NineRouterConnectionViewModel connection }) return;
+        await vm.RefreshNineRouterUsageAsync(connection);
+    }
 }

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -265,6 +265,25 @@ public sealed class ApiClient : IDisposable
         return new NineRouterTestResult(payload.Valid, payload.Error, payload.Refreshed);
     }
 
+    /// <summary>Gets usage limits for a 9Router connection via <c>GET /api/usage/{connectionId}</c>.</summary>
+    /// <param name="connectionId">Connection id from <see cref="NineRouterProvider.Id"/>.</param>
+    /// <param name="force">Whether 9Router should bypass its usage cache.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterUsage> GetUsageAsync(
+        string connectionId,
+        bool force = false,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionId);
+        using var response = await SendWithAuthRetryAsync(
+                HttpMethod.Get,
+                UsagePath(connectionId) + (force ? "?force=1" : ""),
+                body: null,
+                ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterUsage>(response, ct).ConfigureAwait(false);
+    }
+
     /// <summary>Lists client API keys for <c>/v1</c> via <c>GET /api/keys</c>.</summary>
     /// <param name="ct">Token used to cancel the request.</param>
     public async Task<IReadOnlyList<NineRouterApiKey>> ListKeysAsync(CancellationToken ct = default)
@@ -641,6 +660,9 @@ public sealed class ApiClient : IDisposable
 
     private static string ComboPath(string id) =>
         "api/combos/" + Uri.EscapeDataString(id);
+
+    private static string UsagePath(string connectionId) =>
+        "api/usage/" + Uri.EscapeDataString(connectionId);
 
     private static string OAuthPath(string providerId, string action) =>
         "api/oauth/" + Uri.EscapeDataString(providerId) + "/" + action;

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -239,6 +239,41 @@ public sealed record NineRouterValidationResult(bool Valid, string? Error);
 /// <param name="Refreshed">Whether 9Router refreshed OAuth credentials during the test.</param>
 public sealed record NineRouterTestResult(bool Valid, string? Error, bool Refreshed);
 
+/// <summary>Usage limits returned by <c>GET /api/usage/{connectionId}</c>.</summary>
+public sealed record NineRouterUsage
+{
+    /// <summary>Gets the plan reported by the upstream provider, if any.</summary>
+    public string? Plan { get; init; }
+
+    /// <summary>Gets the provider's explanation when usage is unavailable.</summary>
+    public string? Message { get; init; }
+
+    /// <summary>Gets usage windows keyed by their provider-specific names.</summary>
+    public Dictionary<string, NineRouterUsageQuota>? Quotas { get; init; }
+}
+
+/// <summary>One normalized 9Router usage window.</summary>
+public sealed record NineRouterUsageQuota
+{
+    /// <summary>Gets the display name supplied by the provider, if any.</summary>
+    public string? DisplayName { get; init; }
+
+    /// <summary>Gets the consumed amount.</summary>
+    public double? Used { get; init; }
+
+    /// <summary>Gets the total allocation.</summary>
+    public double? Total { get; init; }
+
+    /// <summary>Gets the remaining amount or percentage when the provider supplies one.</summary>
+    public double? Remaining { get; init; }
+
+    /// <summary>Gets the explicit remaining percentage, if supplied.</summary>
+    public double? RemainingPercentage { get; init; }
+
+    /// <summary>Gets the ISO-8601 reset time, if supplied.</summary>
+    public string? ResetAt { get; init; }
+}
+
 /// <summary>
 /// A client API key from <c>GET /api/keys</c>. These keys authenticate callers of
 /// <c>/v1</c>; they are not upstream provider keys.

--- a/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
@@ -132,6 +132,29 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
+    public async Task QuotaSubmenu_TogglesAndSelectsBothViews()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.ToggleQuotaSubmenuCommand.Execute(null);
+        Assert.True(vm.IsQuotaSubmenuExpanded);
+
+        vm.SelectQuotaLimitsCommand.Execute(null);
+        Assert.Equal(SectionKey.Quota, vm.SelectedSection);
+        Assert.True(vm.IsQuotaLimitsSelected);
+
+        await vm.SelectQuotaUsageCommand.ExecuteAsync(null);
+        Assert.True(vm.IsQuotaUsageSelected);
+        Assert.True(vm.IsQuotaUsageActive);
+
+        vm.SelectedSection = SectionKey.Home;
+        Assert.False(vm.IsQuotaUsageActive);
+
+        vm.ToggleQuotaSubmenuCommand.Execute(null);
+        Assert.False(vm.IsQuotaSubmenuExpanded);
+    }
+
+    [Fact]
     public void NineRouterProviderPagination_FiltersAndNavigatesCatalog()
     {
         var vm = new MainWindowViewModel();

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -292,6 +292,38 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
+    public async Task GetUsageAsync_Force_ParsesQuotasAndAddsQuery()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "plan": "pro",
+              "quotas": {
+                "five_hour": {
+                  "displayName": "Primary (5h)",
+                  "used": 25,
+                  "total": 100,
+                  "resetAt": "2026-08-15T12:00:00Z"
+                }
+              }
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var usage = await client.GetUsageAsync("conn/1", force: true);
+
+        Assert.Equal("pro", usage.Plan);
+        var quota = Assert.Single(usage.Quotas!);
+        Assert.Equal("five_hour", quota.Key);
+        Assert.Equal("Primary (5h)", quota.Value.DisplayName);
+        Assert.Equal(25, quota.Value.Used);
+        Assert.Equal(100, quota.Value.Total);
+        Assert.Equal("GET", handler.Requests[0].Method);
+        Assert.Equal("/api/usage/conn%2F1", handler.Requests[0].Path);
+        Assert.Equal("?force=1", handler.Requests[0].Query);
+    }
+
+    [Fact]
     public async Task ListKeysAsync_200WithKeys_ParsesList()
     {
         using var handler = new FakeApiHandler();

--- a/tests/TunnelAgent.Tests/NineRouterConnectionViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterConnectionViewModelTests.cs
@@ -1,0 +1,35 @@
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+using TunnelAgent.ViewModels;
+
+namespace TunnelAgent.Tests;
+
+public sealed class NineRouterConnectionViewModelTests
+{
+    [Fact]
+    public void ApplyUsage_NormalizesUsagePercentages()
+    {
+        var connection = new NineRouterConnectionViewModel(
+            "connection-1", "codex", "Codex", true, "oauth", null);
+
+        connection.ApplyUsage(new NineRouterUsage
+        {
+            Plan = "plus",
+            Quotas = new()
+            {
+                ["primary"] = new() { DisplayName = "Primary", Used = 25, Total = 100 },
+                ["weekly"] = new() { RemainingPercentage = 80 },
+                ["monthly"] = new() { Remaining = 60 },
+                ["credits"] = new() { Total = 1_000, Remaining = 200 },
+                ["unknown"] = new()
+            }
+        });
+
+        Assert.Equal("plus", connection.PlanBadge);
+        Assert.True(connection.HasUsage);
+        Assert.Equal(4, connection.UsageBars.Count);
+        Assert.Equal(0.25, connection.UsageBars[0].Used, 2);
+        Assert.Equal(0.20, connection.UsageBars[1].Used, 2);
+        Assert.Equal(0.40, connection.UsageBars[2].Used, 2);
+        Assert.Equal(0.80, connection.UsageBars[3].Used, 2);
+    }
+}


### PR DESCRIPTION
## Summary
- add Quota sidebar submenus for standard quota and 9Router Usage
- load and normalize 9Router connection usage via its management API
- match the existing yellow stopped-engine warning style

## Validation
- Avalonia build succeeded with a temporary output directory
- dotnet test TunnelAgent.slnx --no-build --no-restore (420 passed, 4 skipped)