### PR TITLE
Add 9Router usage dashboard

### DIFF
--- a/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
@@ -1694,6 +1694,63 @@
   <data name="DashboardView_Summary_Empty" xml:space="preserve">
     <value>Aún no hay solicitudes. Apunta un agente al proxy local para ver la actividad aquí.</value>
   </data>
+  <data name="DashboardView_Tab_Local" xml:space="preserve">
+    <value>Proxy local</value>
+  </data>
+  <data name="DashboardView_Tab_NineRouter" xml:space="preserve">
+    <value>9Router</value>
+  </data>
+  <data name="DashboardView_NineRouter_EngineNotRunning" xml:space="preserve">
+    <value>Inicia 9Router para ver su uso y los detalles de las solicitudes.</value>
+  </data>
+  <data name="DashboardView_NineRouter_Title" xml:space="preserve">
+    <value>Uso de 9Router</value>
+  </data>
+  <data name="DashboardView_NineRouter_Subtitle" xml:space="preserve">
+    <value>Uso en directo y metadatos de solicitudes anonimizados de los últimos 7 días.</value>
+  </data>
+  <data name="DashboardView_NineRouter_Requests" xml:space="preserve">
+    <value>SOLICITUDES</value>
+  </data>
+  <data name="DashboardView_NineRouter_Tokens" xml:space="preserve">
+    <value>TOKENS</value>
+  </data>
+  <data name="DashboardView_NineRouter_Cached" xml:space="preserve">
+    <value>En caché {0}</value>
+  </data>
+  <data name="DashboardView_NineRouter_Cost" xml:space="preserve">
+    <value>COSTE</value>
+  </data>
+  <data name="DashboardView_NineRouter_Active" xml:space="preserve">
+    <value>ACTIVAS</value>
+  </data>
+  <data name="DashboardView_NineRouter_ActiveRequests" xml:space="preserve">
+    <value>Solicitudes activas</value>
+  </data>
+  <data name="DashboardView_NineRouter_ByProvider" xml:space="preserve">
+    <value>Uso por proveedor</value>
+  </data>
+  <data name="DashboardView_NineRouter_CachedLabel" xml:space="preserve">
+    <value>CACHÉ</value>
+  </data>
+  <data name="DashboardView_NineRouter_Empty" xml:space="preserve">
+    <value>Aún no hay uso de 9Router.</value>
+  </data>
+  <data name="DashboardView_NineRouter_RequestDetails" xml:space="preserve">
+    <value>Detalles de solicitudes</value>
+  </data>
+  <data name="DashboardView_NineRouter_RequestDetailsEmpty" xml:space="preserve">
+    <value>No se han registrado detalles de solicitudes.</value>
+  </data>
+  <data name="DashboardView_NineRouter_Connection" xml:space="preserve">
+    <value>CONEXIÓN</value>
+  </data>
+  <data name="DashboardView_NineRouter_Status" xml:space="preserve">
+    <value>ESTADO</value>
+  </data>
+  <data name="DashboardView_NineRouter_Latency" xml:space="preserve">
+    <value>LATENCIA</value>
+  </data>
 
   <data name="Quota_Error_Title" xml:space="preserve">
     <value>Cuota no disponible</value>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -1737,6 +1737,63 @@
   <data name="DashboardView_Summary_Empty" xml:space="preserve">
     <value>No requests yet. Point an agent at the local proxy to see activity here.</value>
   </data>
+  <data name="DashboardView_Tab_Local" xml:space="preserve">
+    <value>Local proxy</value>
+  </data>
+  <data name="DashboardView_Tab_NineRouter" xml:space="preserve">
+    <value>9Router</value>
+  </data>
+  <data name="DashboardView_NineRouter_EngineNotRunning" xml:space="preserve">
+    <value>Start 9Router to view its usage and request details.</value>
+  </data>
+  <data name="DashboardView_NineRouter_Title" xml:space="preserve">
+    <value>9Router usage</value>
+  </data>
+  <data name="DashboardView_NineRouter_Subtitle" xml:space="preserve">
+    <value>Live usage and redacted request metadata from the last 7 days.</value>
+  </data>
+  <data name="DashboardView_NineRouter_Requests" xml:space="preserve">
+    <value>REQUESTS</value>
+  </data>
+  <data name="DashboardView_NineRouter_Tokens" xml:space="preserve">
+    <value>TOKENS</value>
+  </data>
+  <data name="DashboardView_NineRouter_Cached" xml:space="preserve">
+    <value>Cached {0}</value>
+  </data>
+  <data name="DashboardView_NineRouter_Cost" xml:space="preserve">
+    <value>COST</value>
+  </data>
+  <data name="DashboardView_NineRouter_Active" xml:space="preserve">
+    <value>ACTIVE</value>
+  </data>
+  <data name="DashboardView_NineRouter_ActiveRequests" xml:space="preserve">
+    <value>Active requests</value>
+  </data>
+  <data name="DashboardView_NineRouter_ByProvider" xml:space="preserve">
+    <value>Usage by provider</value>
+  </data>
+  <data name="DashboardView_NineRouter_CachedLabel" xml:space="preserve">
+    <value>CACHED</value>
+  </data>
+  <data name="DashboardView_NineRouter_Empty" xml:space="preserve">
+    <value>No 9Router usage yet.</value>
+  </data>
+  <data name="DashboardView_NineRouter_RequestDetails" xml:space="preserve">
+    <value>Request details</value>
+  </data>
+  <data name="DashboardView_NineRouter_RequestDetailsEmpty" xml:space="preserve">
+    <value>No request details have been recorded.</value>
+  </data>
+  <data name="DashboardView_NineRouter_Connection" xml:space="preserve">
+    <value>CONNECTION</value>
+  </data>
+  <data name="DashboardView_NineRouter_Status" xml:space="preserve">
+    <value>STATUS</value>
+  </data>
+  <data name="DashboardView_NineRouter_Latency" xml:space="preserve">
+    <value>LATENCY</value>
+  </data>
 
   <data name="Quota_Error_Title" xml:space="preserve">
     <value>Quota unavailable</value>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -37,6 +37,9 @@ internal sealed record PendingNineRouterOAuth(
     NineRouterOAuthStartResult Start,
     string RedirectUri);
 
+/// <summary>The usage source currently shown on Home.</summary>
+public enum HomeDashboardTab { LocalProxy, NineRouter }
+
 public sealed class RoutingStrategyOption(RoutingStrategy value, string displayKey) : ObservableObject
 {
     public RoutingStrategy Value { get; } = value;
@@ -95,6 +98,7 @@ public partial class MainWindowViewModel : ViewModelBase, IAsyncDisposable
     private readonly UsageService _usage;
     public LogsViewModel Logs { get; } = new();
     public DashboardViewModel Dashboard { get; } = new();
+    public NineRouterUsageViewModel NineRouterUsage { get; }
     public FallbackViewModel Fallback { get; }
     public NineRouterCombosViewModel NineRouterCombos { get; }
     private bool _logsInitialLoadPending;
@@ -161,6 +165,7 @@ SelectedSection is SectionKey.Logs;
     }
 
     [ObservableProperty] private SectionKey _selectedSection = SectionKey.Home;
+    [ObservableProperty] private HomeDashboardTab _homeDashboardTab = HomeDashboardTab.LocalProxy;
     [ObservableProperty] private bool _isSidebarCollapsed;
     [ObservableProperty] private bool _isFallbackSubmenuExpanded;
     [ObservableProperty] private bool _isDark;
@@ -451,6 +456,9 @@ SelectedSection is SectionKey.Logs;
         PerplexityModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
         NineRouterModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
         AvailableModelGroups = new ObservableCollection<AvailableModelGroupViewModel>();
+        NineRouterUsage = new NineRouterUsageViewModel(
+            () => NineRouterEngine.Port,
+            () => IsNineRouterEngineRunning);
         NineRouterCombos = new NineRouterCombosViewModel(
             () => NineRouterEngine.Port,
             () => IsNineRouterEngineRunning,
@@ -955,6 +963,11 @@ SelectedSection is SectionKey.Logs;
     public bool NineRouterUpdateAvailable => NineRouterEngine.UpdateAvailable;
     public string NineRouterStatusText => BuildEngineStatusText(NineRouterEngine);
     public ServerState NineRouterServerState => ToServerState(NineRouterEngine.State);
+    public int HomeDashboardTabIndex => (int)HomeDashboardTab;
+    public bool IsLocalHomeDashboardTab => HomeDashboardTab == HomeDashboardTab.LocalProxy;
+    public bool IsNineRouterHomeDashboardTab => HomeDashboardTab == HomeDashboardTab.NineRouter;
+    public bool ShowNineRouterUsage => IsNineRouterHomeDashboardTab && IsNineRouterEngineRunning;
+    public bool ShowNineRouterUsageWarning => IsNineRouterHomeDashboardTab && !IsNineRouterEngineRunning;
     public int NineRouterPort => _settings.Current.GetOrAddEngine(EngineCatalog.NineRouter.Id, EngineCatalog.NineRouter.DefaultPort).Port;
     public string NineRouterEndpointUrl => $"http://127.0.0.1:{NineRouterPort}";
     public string NineRouterDashboardUrl => $"http://127.0.0.1:{NineRouterPort}/dashboard";
@@ -965,7 +978,11 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(ConfigTabIndex));
         UpdateLogsPollingState();
 
-        if (value == SectionKey.Quota)
+        if (value == SectionKey.Home && ShowNineRouterUsage)
+        {
+            _ = NineRouterUsage.RefreshAsync();
+        }
+        else if (value == SectionKey.Quota)
         {
             RefreshQuotaNavigation();
             _ = ScanAndRefreshQuotaOnceAsync();
@@ -985,6 +1002,24 @@ SelectedSection is SectionKey.Logs;
             FocusedConfigEngineId = EngineCatalog.NineRouter.Id;
             _ = RefreshNineRouterNodeMissingAsync();
         }
+    }
+
+    partial void OnHomeDashboardTabChanged(HomeDashboardTab value)
+    {
+        OnPropertyChanged(nameof(HomeDashboardTabIndex));
+        OnPropertyChanged(nameof(IsLocalHomeDashboardTab));
+        OnPropertyChanged(nameof(IsNineRouterHomeDashboardTab));
+        OnPropertyChanged(nameof(ShowNineRouterUsage));
+        OnPropertyChanged(nameof(ShowNineRouterUsageWarning));
+        if (ShowNineRouterUsage)
+            _ = NineRouterUsage.RefreshAsync();
+    }
+
+    [RelayCommand]
+    private void SelectHomeDashboardTab(string tab)
+    {
+        if (Enum.TryParse<HomeDashboardTab>(tab, out var selected))
+            HomeDashboardTab = selected;
     }
 
     partial void OnProvidersEngineIdChanged(string value)
@@ -1394,7 +1429,12 @@ SelectedSection is SectionKey.Logs;
                         }
                     }
                     if (isNineRouter)
+                    {
+                        NineRouterUsage.NotifyEngineStateChanged();
                         _ = RefreshNineRouterConnectionsAsync();
+                        if (SelectedSection == SectionKey.Home && IsNineRouterHomeDashboardTab)
+                            _ = NineRouterUsage.RefreshAsync();
+                    }
                 }
                 else if (engine.State == EngineState.Stopped || engine.State == EngineState.Error)
                 {
@@ -1417,6 +1457,7 @@ SelectedSection is SectionKey.Logs;
                         _allNineRouterProviders.Clear();
                         NineRouterProviderPageNavigationItems.Clear();
                         OnPropertyChanged(nameof(HasNineRouterConnections));
+                        NineRouterUsage.NotifyEngineStateChanged();
                     }
                     modelGroups?.Clear();
                     if (isCliProxy)
@@ -1605,6 +1646,9 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(NineRouterEndpointUrl));
         OnPropertyChanged(nameof(NineRouterDashboardUrl));
         OnPropertyChanged(nameof(IsNineRouterEngineRunning));
+        OnPropertyChanged(nameof(ShowNineRouterUsage));
+        OnPropertyChanged(nameof(ShowNineRouterUsageWarning));
+        NineRouterUsage.NotifyEngineStateChanged();
         NineRouterCombos.NotifyEngineStateChanged();
         OnPropertyChanged(nameof(EndpointUrl));
         OnPropertyChanged(nameof(Port));

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterUsageViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterUsageViewModel.cs
@@ -1,0 +1,346 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using TunnelAgent.Infrastructure.Engine.NineRouter;
+
+namespace TunnelAgent.ViewModels;
+
+/// <summary>Displays 9Router's live usage aggregates and redacted request metadata on Home.</summary>
+public sealed partial class NineRouterUsageViewModel : ViewModelBase
+{
+    private const int PageSize = 20;
+    private readonly Func<int> _port;
+    private readonly Func<bool> _isEngineRunning;
+
+    /// <summary>Creates the 9Router usage panel.</summary>
+    /// <param name="port">Gets the active 9Router management port.</param>
+    /// <param name="isEngineRunning">Gets whether 9Router is running.</param>
+    public NineRouterUsageViewModel(Func<int> port, Func<bool> isEngineRunning)
+    {
+        _port = port;
+        _isEngineRunning = isEngineRunning;
+    }
+
+    /// <summary>Gets the provider aggregates returned by 9Router.</summary>
+    public ObservableCollection<NineRouterUsageProviderRow> ProviderRows { get; } = [];
+
+    /// <summary>Gets the active requests returned by 9Router.</summary>
+    public ObservableCollection<NineRouterActiveRequest> ActiveRequests { get; } = [];
+
+    /// <summary>Gets the current page of redacted request metadata.</summary>
+    public ObservableCollection<NineRouterUsageRequestRow> RequestRows { get; } = [];
+
+    /// <summary>Gets the navigation items for request-detail paging.</summary>
+    public ObservableCollection<LogPageItem> PageNavigationItems { get; } = [];
+
+    /// <summary>Gets whether the 9Router process is available.</summary>
+    public bool IsEngineRunning => _isEngineRunning();
+
+    /// <summary>Gets whether the panel has loaded a response from 9Router.</summary>
+    [ObservableProperty] private bool _isLoaded;
+
+    /// <summary>Gets whether a request to 9Router is in progress.</summary>
+    [ObservableProperty] private bool _isBusy;
+
+    /// <summary>Gets a safe error message for a failed 9Router request.</summary>
+    [ObservableProperty] private string? _errorMessage;
+
+    /// <summary>Gets the total request count for the last seven days.</summary>
+    [ObservableProperty] private string _totalRequests = "0";
+
+    /// <summary>Gets prompt plus completion tokens for the last seven days.</summary>
+    [ObservableProperty] private string _totalTokens = "0";
+
+    /// <summary>Gets cached tokens for the last seven days.</summary>
+    [ObservableProperty] private string _cachedTokens = "0";
+
+    /// <summary>Gets cost reported by 9Router for the last seven days.</summary>
+    [ObservableProperty] private string _totalCost = "$0.00";
+
+    /// <summary>Gets the number of requests currently in flight.</summary>
+    [ObservableProperty] private string _activeRequestCount = "0";
+
+    /// <summary>Gets the total number of request-detail records.</summary>
+    [ObservableProperty] private int _totalRequestDetails;
+
+    /// <summary>Gets the current one-based request-details page.</summary>
+    [ObservableProperty] private int _currentPage = 1;
+
+    /// <summary>Gets the total number of request-details pages.</summary>
+    [ObservableProperty] private int _totalPages = 1;
+
+    /// <summary>Gets whether the latest refresh failed.</summary>
+    public bool HasError => !string.IsNullOrWhiteSpace(ErrorMessage);
+
+    /// <summary>Gets whether provider aggregates exist.</summary>
+    public bool HasProviderRows => ProviderRows.Count > 0;
+
+    /// <summary>Gets whether active requests exist.</summary>
+    public bool HasActiveRequests => ActiveRequests.Count > 0;
+
+    /// <summary>Gets whether request details exist.</summary>
+    public bool HasRequestRows => RequestRows.Count > 0;
+
+    /// <summary>Gets whether a previous request-details page exists.</summary>
+    public bool CanGoPrev => CurrentPage > 1;
+
+    /// <summary>Gets whether a next request-details page exists.</summary>
+    public bool CanGoNext => CurrentPage < TotalPages;
+
+    /// <summary>Gets a compact page label.</summary>
+    public string PageLabel => TotalPages <= 1 ? "" : $"{CurrentPage} / {TotalPages}";
+
+    partial void OnErrorMessageChanged(string? value) => OnPropertyChanged(nameof(HasError));
+
+    partial void OnCurrentPageChanged(int value)
+    {
+        OnPropertyChanged(nameof(CanGoPrev));
+        OnPropertyChanged(nameof(CanGoNext));
+        OnPropertyChanged(nameof(PageLabel));
+        RebuildPageNavigation();
+    }
+
+    partial void OnTotalPagesChanged(int value)
+    {
+        OnPropertyChanged(nameof(CanGoNext));
+        OnPropertyChanged(nameof(PageLabel));
+        RebuildPageNavigation();
+    }
+
+    /// <summary>Updates engine-dependent state and clears sensitive runtime data after 9Router stops.</summary>
+    public void NotifyEngineStateChanged()
+    {
+        OnPropertyChanged(nameof(IsEngineRunning));
+        if (!IsEngineRunning) Clear();
+    }
+
+    /// <summary>Loads 9Router's seven-day usage aggregates and the selected page of request details.</summary>
+    [RelayCommand]
+    public async Task RefreshAsync()
+    {
+        if (!IsEngineRunning)
+        {
+            Clear();
+            return;
+        }
+        if (IsBusy) return;
+
+        IsBusy = true;
+        ErrorMessage = null;
+        try
+        {
+            using var client = new ApiClient(_port());
+            var stats = await client.GetUsageStatsAsync("7d");
+            var details = await client.ListRequestDetailsAsync(CurrentPage, PageSize);
+            Apply(stats, details);
+        }
+        catch (Exception ex)
+        {
+            ErrorMessage = ex.Message;
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    [RelayCommand] private async Task FirstPageAsync()
+    {
+        if (!CanGoPrev) return;
+        CurrentPage = 1;
+        await RefreshAsync();
+    }
+
+    [RelayCommand] private async Task PrevPageAsync()
+    {
+        if (!CanGoPrev) return;
+        CurrentPage--;
+        await RefreshAsync();
+    }
+
+    [RelayCommand] private async Task NextPageAsync()
+    {
+        if (!CanGoNext) return;
+        CurrentPage++;
+        await RefreshAsync();
+    }
+
+    [RelayCommand] private async Task LastPageAsync()
+    {
+        if (!CanGoNext) return;
+        CurrentPage = TotalPages;
+        await RefreshAsync();
+    }
+
+    [RelayCommand] private async Task GoToPageAsync(LogPageItem? item)
+    {
+        if (item?.PageNumber is not { } page || page == CurrentPage || page < 1 || page > TotalPages) return;
+        CurrentPage = page;
+        await RefreshAsync();
+    }
+
+    private void Apply(NineRouterUsageStats stats, NineRouterRequestDetailsPage details)
+    {
+        TotalRequests = FormatCount(stats.TotalRequests);
+        TotalTokens = FormatCount(stats.TotalPromptTokens + stats.TotalCompletionTokens);
+        CachedTokens = FormatCount(stats.TotalCachedTokens);
+        TotalCost = "$" + stats.TotalCost.ToString("N2", CultureInfo.InvariantCulture);
+        ActiveRequestCount = FormatCount(stats.ActiveRequests.Sum(request => request.Count));
+
+        ProviderRows.Clear();
+        foreach (var provider in stats.ByProvider.OrderByDescending(entry => entry.Value.Requests))
+            ProviderRows.Add(new NineRouterUsageProviderRow(provider.Key, provider.Value));
+
+        ActiveRequests.Clear();
+        foreach (var request in stats.ActiveRequests)
+            ActiveRequests.Add(request);
+
+        RequestRows.Clear();
+        foreach (var detail in details.Details)
+            RequestRows.Add(new NineRouterUsageRequestRow(detail));
+
+        var pagination = details.Pagination;
+        TotalRequestDetails = pagination.TotalItems;
+        TotalPages = Math.Max(1, pagination.TotalPages);
+        CurrentPage = Math.Clamp(pagination.Page, 1, TotalPages);
+        IsLoaded = true;
+        OnPropertyChanged(nameof(HasProviderRows));
+        OnPropertyChanged(nameof(HasActiveRequests));
+        OnPropertyChanged(nameof(HasRequestRows));
+    }
+
+    private void Clear()
+    {
+        ProviderRows.Clear();
+        ActiveRequests.Clear();
+        RequestRows.Clear();
+        PageNavigationItems.Clear();
+        TotalRequests = TotalTokens = CachedTokens = ActiveRequestCount = "0";
+        TotalCost = "$0.00";
+        TotalRequestDetails = 0;
+        CurrentPage = 1;
+        TotalPages = 1;
+        IsLoaded = false;
+        ErrorMessage = null;
+        OnPropertyChanged(nameof(HasProviderRows));
+        OnPropertyChanged(nameof(HasActiveRequests));
+        OnPropertyChanged(nameof(HasRequestRows));
+    }
+
+    private void RebuildPageNavigation()
+    {
+        PageNavigationItems.Clear();
+        if (TotalPages <= 1) return;
+
+        var pages = new SortedSet<int> { 1, TotalPages };
+        for (var page = Math.Max(2, CurrentPage - 2); page <= Math.Min(TotalPages - 1, CurrentPage + 2); page++)
+            pages.Add(page);
+
+        var previous = 0;
+        foreach (var page in pages)
+        {
+            if (page - previous > 1)
+                PageNavigationItems.Add(new LogPageItem(null, "…", false, true));
+            PageNavigationItems.Add(new LogPageItem(page, page.ToString(CultureInfo.InvariantCulture), page == CurrentPage, false));
+            previous = page;
+        }
+    }
+
+    private static string FormatCount(long value) => value switch
+    {
+        >= 1_000_000_000 => (value / 1_000_000_000d).ToString("0.0", CultureInfo.InvariantCulture) + "B",
+        >= 1_000_000 => (value / 1_000_000d).ToString("0.0", CultureInfo.InvariantCulture) + "M",
+        >= 1_000 => (value / 1_000d).ToString("0.0", CultureInfo.InvariantCulture) + "K",
+        _ => value.ToString(CultureInfo.InvariantCulture)
+    };
+}
+
+/// <summary>One provider aggregate in the 9Router Home panel.</summary>
+public sealed class NineRouterUsageProviderRow
+{
+    /// <summary>Creates a provider aggregate row.</summary>
+    public NineRouterUsageProviderRow(string provider, NineRouterUsageBucket usage)
+    {
+        Provider = string.IsNullOrWhiteSpace(provider) ? "—" : provider;
+        Requests = FormatCount(usage.Requests);
+        Tokens = FormatCount(usage.PromptTokens + usage.CompletionTokens);
+        CachedTokens = FormatCount(usage.CachedTokens);
+        Cost = "$" + usage.Cost.ToString("N2", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>Gets the provider label.</summary>
+    public string Provider { get; }
+    /// <summary>Gets the formatted request count.</summary>
+    public string Requests { get; }
+    /// <summary>Gets formatted prompt plus completion tokens.</summary>
+    public string Tokens { get; }
+    /// <summary>Gets formatted cached tokens.</summary>
+    public string CachedTokens { get; }
+    /// <summary>Gets the formatted reported cost.</summary>
+    public string Cost { get; }
+
+    private static string FormatCount(long value) => value.ToString("N0", CultureInfo.InvariantCulture);
+}
+
+/// <summary>One redacted request-detail row in the 9Router Home panel.</summary>
+public sealed class NineRouterUsageRequestRow
+{
+    /// <summary>Creates a display row from 9Router's redacted request metadata.</summary>
+    public NineRouterUsageRequestRow(NineRouterRequestDetail detail)
+    {
+        Provider = detail.Provider ?? "—";
+        Model = detail.Model ?? "—";
+        Connection = detail.ConnectionId ?? "—";
+        Status = detail.Status ?? "—";
+        Timestamp = FormatTimestamp(detail.Timestamp);
+        Tokens = FormatCount(InputTokens(detail.Tokens) + OutputTokens(detail.Tokens));
+        Latency = FormatLatency(detail.Latency);
+    }
+
+    /// <summary>Gets the provider label.</summary>
+    public string Provider { get; }
+    /// <summary>Gets the model label.</summary>
+    public string Model { get; }
+    /// <summary>Gets the selected connection id.</summary>
+    public string Connection { get; }
+    /// <summary>Gets the request status.</summary>
+    public string Status { get; }
+    /// <summary>Gets the formatted request timestamp.</summary>
+    public string Timestamp { get; }
+    /// <summary>Gets the formatted token count.</summary>
+    public string Tokens { get; }
+    /// <summary>Gets the formatted elapsed time.</summary>
+    public string Latency { get; }
+
+    private static long InputTokens(NineRouterUsageTokens? tokens) =>
+        tokens?.PromptTokens is > 0 ? tokens.PromptTokens : tokens?.InputTokens ?? 0;
+
+    private static long OutputTokens(NineRouterUsageTokens? tokens) =>
+        tokens?.CompletionTokens is > 0 ? tokens.CompletionTokens : tokens?.OutputTokens ?? 0;
+
+    private static string FormatTimestamp(string? timestamp) =>
+        DateTimeOffset.TryParse(timestamp, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var value)
+            ? value.LocalDateTime.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
+            : "—";
+
+    private static string FormatLatency(JsonElement? latency)
+    {
+        if (latency is not { ValueKind: JsonValueKind.Object } value) return "—";
+        foreach (var name in new[] { "total", "totalMs", "duration", "latency" })
+        {
+            if (value.TryGetProperty(name, out var field) && field.TryGetDouble(out var milliseconds))
+                return milliseconds >= 1000
+                    ? (milliseconds / 1000).ToString("0.0", CultureInfo.InvariantCulture) + "s"
+                    : milliseconds.ToString("0", CultureInfo.InvariantCulture) + "ms";
+        }
+        return "—";
+    }
+
+    private static string FormatCount(long value) => value.ToString("N0", CultureInfo.InvariantCulture);
+}

--- a/src/TunnelAgent.Avalonia/Views/DashboardView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/DashboardView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:TunnelAgent.ViewModels"
+             xmlns:nineRouter="using:TunnelAgent.Infrastructure.Engine.NineRouter"
              xmlns:ctrl="using:TunnelAgent.Controls"
              xmlns:lucide="using:IconPacks.Avalonia.Lucide"
              xmlns:l="using:TunnelAgent.Services"
@@ -32,8 +33,15 @@
             <TextBlock Classes="page-sub" Text="{l:Loc DashboardView_Subtitle}" />
         </StackPanel>
 
+        <ctrl:SlidingTabBar HorizontalAlignment="Left" MinWidth="280" SelectedIndex="{Binding HomeDashboardTabIndex}">
+            <ctrl:SlidingTabBar.Tabs>
+                <ctrl:SlidingTab Header="{l:Loc DashboardView_Tab_Local}" Command="{Binding SelectHomeDashboardTabCommand}" CommandParameter="LocalProxy" />
+                <ctrl:SlidingTab Header="{l:Loc DashboardView_Tab_NineRouter}" Command="{Binding SelectHomeDashboardTabCommand}" CommandParameter="NineRouter" />
+            </ctrl:SlidingTabBar.Tabs>
+        </ctrl:SlidingTabBar>
+
         <!-- Toolbar: range tabs + refresh -->
-        <Border Classes="card" Padding="14">
+        <Border Classes="card" Padding="14" IsVisible="{Binding IsLocalHomeDashboardTab}">
             <StackPanel Spacing="12">
                 <Grid ColumnDefinitions="*,Auto" VerticalAlignment="Center">
                     <ctrl:SlidingTabBar Grid.Column="0" HorizontalAlignment="Left"
@@ -78,8 +86,170 @@
             </StackPanel>
         </Border>
 
+        <!-- 9Router live usage -->
+        <Border Background="#18F59E0B" BorderBrush="#44F59E0B" BorderThickness="1" CornerRadius="8" Padding="10"
+                IsVisible="{Binding ShowNineRouterUsageWarning}">
+            <StackPanel Spacing="4">
+                <TextBlock Classes="row-label" Text="{l:Loc Fallback_AddModelPopup_ServerWarning_Title}" />
+                <TextBlock Classes="row-desc" TextWrapping="Wrap" Text="{l:Loc DashboardView_NineRouter_EngineNotRunning}" />
+            </StackPanel>
+        </Border>
+        <Border Classes="card" Padding="18" IsVisible="{Binding ShowNineRouterUsage}">
+            <StackPanel Spacing="14">
+                <Grid ColumnDefinitions="*,Auto">
+                    <StackPanel>
+                        <TextBlock Text="{l:Loc DashboardView_NineRouter_Title}" FontSize="15" FontWeight="SemiBold"
+                                   Foreground="{DynamicResource AccentBrush}" />
+                        <TextBlock Classes="row-desc" Text="{l:Loc DashboardView_NineRouter_Subtitle}" />
+                    </StackPanel>
+                    <Button Grid.Column="1" Classes="icon" ToolTip.Tip="{l:Loc DashboardView_Refresh}"
+                            Command="{Binding NineRouterUsage.RefreshCommand}">
+                        <lucide:PackIconLucide Kind="RefreshCw" Width="14" Height="14"
+                                               Classes.spin="{Binding NineRouterUsage.IsBusy}" />
+                    </Button>
+                </Grid>
+
+                <TextBlock Text="{Binding NineRouterUsage.ErrorMessage}" Foreground="{DynamicResource ErrBrush}"
+                           IsVisible="{Binding NineRouterUsage.HasError}" />
+
+                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="12">
+                    <Border Grid.Column="0" Classes="card" Padding="14,12">
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Requests}" />
+                            <TextBlock Text="{Binding NineRouterUsage.TotalRequests}" FontSize="22" FontWeight="Bold" Foreground="{DynamicResource AccentBrush}" />
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="1" Classes="card" Padding="14,12">
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Tokens}" />
+                            <TextBlock Text="{Binding NineRouterUsage.TotalTokens}" FontSize="22" FontWeight="Bold" Foreground="{DynamicResource AccentBrush}" />
+                            <TextBlock Classes="row-desc" Text="{l:LocFormat Key=DashboardView_NineRouter_Cached, Path=NineRouterUsage.CachedTokens}" />
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="2" Classes="card" Padding="14,12">
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Cost}" />
+                            <TextBlock Text="{Binding NineRouterUsage.TotalCost}" FontSize="22" FontWeight="Bold" Foreground="{DynamicResource WarnBrush}" />
+                        </StackPanel>
+                    </Border>
+                    <Border Grid.Column="3" Classes="card" Padding="14,12">
+                        <StackPanel Spacing="4">
+                            <TextBlock Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Active}" />
+                            <TextBlock Text="{Binding NineRouterUsage.ActiveRequestCount}" FontSize="22" FontWeight="Bold" Foreground="{DynamicResource OkBrush}" />
+                        </StackPanel>
+                    </Border>
+                </Grid>
+
+                <StackPanel Spacing="8" IsVisible="{Binding NineRouterUsage.HasActiveRequests}">
+                    <TextBlock Text="{l:Loc DashboardView_NineRouter_ActiveRequests}" FontWeight="SemiBold" />
+                    <ItemsControl ItemsSource="{Binding NineRouterUsage.ActiveRequests}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="nineRouter:NineRouterActiveRequest">
+                                <Grid ColumnDefinitions="2*,2*,2*,Auto" Margin="4,0">
+                                    <TextBlock Grid.Column="0" Text="{Binding Provider}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="1" Text="{Binding Model}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="2" Text="{Binding Account}" Foreground="{DynamicResource FgMutedBrush}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="3" Text="{Binding Count}" FontWeight="SemiBold" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </StackPanel>
+
+                <StackPanel Spacing="8">
+                    <TextBlock Text="{l:Loc DashboardView_NineRouter_ByProvider}" FontWeight="SemiBold" />
+                    <Grid ColumnDefinitions="3*,*,*,*,*" Margin="4,0">
+                        <TextBlock Grid.Column="0" Classes="section-label" Text="{l:Loc DashboardView_Summary_Provider}" />
+                        <TextBlock Grid.Column="1" Classes="section-label" Text="{l:Loc DashboardView_Summary_Calls}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="2" Classes="section-label" Text="{l:Loc DashboardView_Summary_Tokens}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="3" Classes="section-label" Text="{l:Loc DashboardView_NineRouter_CachedLabel}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="4" Classes="section-label" Text="{l:Loc DashboardView_Summary_Cost}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <ItemsControl ItemsSource="{Binding NineRouterUsage.ProviderRows}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:NineRouterUsageProviderRow">
+                                <Grid ColumnDefinitions="3*,*,*,*,*" Margin="4,0">
+                                    <TextBlock Grid.Column="0" Text="{Binding Provider}" FontWeight="SemiBold" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="1" Text="{Binding Requests}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="2" Text="{Binding Tokens}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="3" Text="{Binding CachedTokens}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="4" Text="{Binding Cost}" HorizontalAlignment="Right" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock Text="{l:Loc DashboardView_NineRouter_Empty}" Classes="row-desc"
+                               IsVisible="{Binding !NineRouterUsage.HasProviderRows}" />
+                </StackPanel>
+
+                <StackPanel Spacing="8">
+                    <Grid ColumnDefinitions="*,Auto">
+                        <TextBlock Text="{l:Loc DashboardView_NineRouter_RequestDetails}" FontWeight="SemiBold" />
+                        <TextBlock Grid.Column="1" Text="{Binding NineRouterUsage.PageLabel}" Classes="row-desc" />
+                    </Grid>
+                    <Grid ColumnDefinitions="1.1*,2*,1.4*,*,*,*,1.5*" Margin="4,0">
+                        <TextBlock Grid.Column="0" Classes="section-label" Text="{l:Loc DashboardView_Summary_Provider}" />
+                        <TextBlock Grid.Column="1" Classes="section-label" Text="{l:Loc DashboardView_Summary_Model}" />
+                        <TextBlock Grid.Column="2" Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Connection}" />
+                        <TextBlock Grid.Column="3" Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Status}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="4" Classes="section-label" Text="{l:Loc DashboardView_Summary_Tokens}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="5" Classes="section-label" Text="{l:Loc DashboardView_NineRouter_Latency}" HorizontalAlignment="Right" />
+                        <TextBlock Grid.Column="6" Classes="section-label" Text="{l:Loc DashboardView_Summary_Last}" HorizontalAlignment="Right" />
+                    </Grid>
+                    <ItemsControl ItemsSource="{Binding NineRouterUsage.RequestRows}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:NineRouterUsageRequestRow">
+                                <Grid ColumnDefinitions="1.1*,2*,1.4*,*,*,*,1.5*" Margin="4,0">
+                                    <TextBlock Grid.Column="0" Text="{Binding Provider}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="1" Text="{Binding Model}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="2" Text="{Binding Connection}" Foreground="{DynamicResource FgMutedBrush}" TextTrimming="CharacterEllipsis" />
+                                    <TextBlock Grid.Column="3" Text="{Binding Status}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="4" Text="{Binding Tokens}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="5" Text="{Binding Latency}" HorizontalAlignment="Right" />
+                                    <TextBlock Grid.Column="6" Text="{Binding Timestamp}" HorizontalAlignment="Right" Foreground="{DynamicResource FgFaintBrush}" FontSize="11" />
+                                </Grid>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock Text="{l:Loc DashboardView_NineRouter_RequestDetailsEmpty}" Classes="row-desc"
+                               IsVisible="{Binding !NineRouterUsage.HasRequestRows}" />
+
+                    <StackPanel Orientation="Horizontal" Spacing="4" HorizontalAlignment="Center"
+                                IsVisible="{Binding NineRouterUsage.HasRequestRows}">
+                        <Button Classes="icon-btn" IsVisible="{Binding NineRouterUsage.CanGoPrev}" Command="{Binding NineRouterUsage.FirstPageCommand}">
+                            <lucide:PackIconLucide Kind="ChevronsLeft" Width="14" Height="14" />
+                        </Button>
+                        <Button Classes="icon-btn" IsVisible="{Binding NineRouterUsage.CanGoPrev}" Command="{Binding NineRouterUsage.PrevPageCommand}">
+                            <lucide:PackIconLucide Kind="ChevronLeft" Width="14" Height="14" />
+                        </Button>
+                        <ItemsControl ItemsSource="{Binding NineRouterUsage.PageNavigationItems}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate><StackPanel Orientation="Horizontal" Spacing="3" /></ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                            <ItemsControl.ItemTemplate>
+                                <DataTemplate x:DataType="vm:LogPageItem">
+                                    <Panel>
+                                        <Button Classes="icon-btn page" Classes.current="{Binding IsCurrent}" MinWidth="24" Padding="6,4"
+                                                Content="{Binding Label}" IsVisible="{Binding !IsEllipsis}"
+                                                Command="{Binding $parent[ItemsControl].DataContext.NineRouterUsage.GoToPageCommand}" CommandParameter="{Binding}" />
+                                        <TextBlock Text="{Binding Label}" IsVisible="{Binding IsEllipsis}" Padding="6,4" />
+                                    </Panel>
+                                </DataTemplate>
+                            </ItemsControl.ItemTemplate>
+                        </ItemsControl>
+                        <Button Classes="icon-btn" IsVisible="{Binding NineRouterUsage.CanGoNext}" Command="{Binding NineRouterUsage.NextPageCommand}">
+                            <lucide:PackIconLucide Kind="ChevronRight" Width="14" Height="14" />
+                        </Button>
+                        <Button Classes="icon-btn" IsVisible="{Binding NineRouterUsage.CanGoNext}" Command="{Binding NineRouterUsage.LastPageCommand}">
+                            <lucide:PackIconLucide Kind="ChevronsRight" Width="14" Height="14" />
+                        </Button>
+                    </StackPanel>
+                </StackPanel>
+            </StackPanel>
+        </Border>
+
         <!-- Stat cards row 1 -->
-        <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="12">
+        <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="12" IsVisible="{Binding IsLocalHomeDashboardTab}">
             <Border Grid.Column="0" Classes="card" Padding="18,16">
                 <StackPanel Spacing="6">
                     <TextBlock Classes="section-label" Text="{l:Loc DashboardView_Card_TotalCalls}" />
@@ -118,7 +288,7 @@
         </Grid>
 
         <!-- Stat cards row 2 (tokens — placeholder) -->
-        <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="12">
+        <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="12" IsVisible="{Binding IsLocalHomeDashboardTab}">
             <Border Grid.Column="0" Classes="card" Padding="18,16">
                 <StackPanel Spacing="6">
                     <TextBlock Classes="section-label" Text="{l:Loc DashboardView_Card_TotalTokens}" />
@@ -166,7 +336,7 @@ Foreground="{DynamicResource AccentBrush}" />
         </Grid>
 
         <!-- Usage chart -->
-        <Border Classes="card" Padding="18">
+        <Border Classes="card" Padding="18" IsVisible="{Binding IsLocalHomeDashboardTab}">
             <StackPanel Spacing="14">
                 <Grid ColumnDefinitions="*,Auto">
                     <StackPanel Grid.Column="0">
@@ -214,7 +384,7 @@ Foreground="{DynamicResource AccentBrush}" />
         </Border>
 
         <!-- Usage summary (by provider / by model) -->
-        <Border Classes="card">
+        <Border Classes="card" IsVisible="{Binding IsLocalHomeDashboardTab}">
             <StackPanel>
                 <Grid Margin="16,14,16,10" ColumnDefinitions="Auto,Auto,*">
                     <TextBlock Grid.Column="0" Text="{l:Loc DashboardView_Summary_Title}"

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -275,6 +275,42 @@ public sealed class ApiClient : IDisposable
         return payload.Keys ?? [];
     }
 
+    /// <summary>Gets usage aggregates from <c>GET /api/usage/stats</c>.</summary>
+    /// <param name="period">One of <c>today</c>, <c>24h</c>, <c>7d</c>, <c>30d</c>, <c>60d</c>, or <c>all</c>.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterUsageStats> GetUsageStatsAsync(string period = "7d", CancellationToken ct = default)
+    {
+        if (period is not ("today" or "24h" or "7d" or "30d" or "60d" or "all"))
+            throw new ArgumentOutOfRangeException(nameof(period), "Unsupported 9Router usage period.");
+
+        using var response = await SendWithAuthRetryAsync(
+            HttpMethod.Get,
+            "api/usage/stats?period=" + Uri.EscapeDataString(period),
+            body: null,
+            ct).ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterUsageStats>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Gets one page of redacted request metadata from <c>GET /api/usage/request-details</c>.</summary>
+    /// <param name="page">One-based page number.</param>
+    /// <param name="pageSize">Records per page, from 1 to 100.</param>
+    /// <param name="ct">Token used to cancel the request.</param>
+    public async Task<NineRouterRequestDetailsPage> ListRequestDetailsAsync(
+        int page = 1,
+        int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        if (page < 1) throw new ArgumentOutOfRangeException(nameof(page));
+        if (pageSize is < 1 or > 100) throw new ArgumentOutOfRangeException(nameof(pageSize));
+
+        using var response = await SendWithAuthRetryAsync(
+            HttpMethod.Get,
+            $"api/usage/request-details?page={page}&pageSize={pageSize}",
+            body: null,
+            ct).ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterRequestDetailsPage>(response, ct).ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Starts a curated OAuth flow via <c>GET /api/oauth/{provider}/authorize</c>
     /// (Claude, Gemini CLI) or <c>GET /api/oauth/{provider}/device-code</c>

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -280,6 +280,123 @@ public sealed record NineRouterCreatedApiKey
     public string? MachineId { get; init; }
 }
 
+/// <summary>Aggregated usage returned by <c>GET /api/usage/stats</c>.</summary>
+public sealed record NineRouterUsageStats
+{
+    /// <summary>Gets the request count for the selected period.</summary>
+    public long TotalRequests { get; init; }
+    /// <summary>Gets total prompt/input tokens.</summary>
+    public long TotalPromptTokens { get; init; }
+    /// <summary>Gets total completion/output tokens.</summary>
+    public long TotalCompletionTokens { get; init; }
+    /// <summary>Gets total cached tokens.</summary>
+    public long TotalCachedTokens { get; init; }
+    /// <summary>Gets the cost reported by 9Router.</summary>
+    public double TotalCost { get; init; }
+    /// <summary>Gets usage grouped by provider.</summary>
+    public Dictionary<string, NineRouterUsageBucket> ByProvider { get; init; } = [];
+    /// <summary>Gets currently active requests.</summary>
+    public List<NineRouterActiveRequest> ActiveRequests { get; init; } = [];
+}
+
+/// <summary>One grouped usage value returned by 9Router.</summary>
+public sealed record NineRouterUsageBucket
+{
+    /// <summary>Gets the request count.</summary>
+    public long Requests { get; init; }
+    /// <summary>Gets prompt/input tokens.</summary>
+    public long PromptTokens { get; init; }
+    /// <summary>Gets completion/output tokens.</summary>
+    public long CompletionTokens { get; init; }
+    /// <summary>Gets cached tokens.</summary>
+    public long CachedTokens { get; init; }
+    /// <summary>Gets reported cost.</summary>
+    public double Cost { get; init; }
+}
+
+/// <summary>One active request returned by 9Router.</summary>
+public sealed record NineRouterActiveRequest
+{
+    /// <summary>Gets the requested model.</summary>
+    public string? Model { get; init; }
+    /// <summary>Gets the upstream provider.</summary>
+    public string? Provider { get; init; }
+    /// <summary>Gets the selected connection label.</summary>
+    public string? Account { get; init; }
+    /// <summary>Gets the number of matching active requests.</summary>
+    public long Count { get; init; }
+}
+
+/// <summary>One request record returned by <c>GET /api/usage/request-details</c>.</summary>
+public sealed record NineRouterRequestDetail
+{
+    /// <summary>Gets the request id.</summary>
+    public string? Id { get; init; }
+    /// <summary>Gets the upstream provider.</summary>
+    public string? Provider { get; init; }
+    /// <summary>Gets the requested model.</summary>
+    public string? Model { get; init; }
+    /// <summary>Gets the 9Router connection id.</summary>
+    public string? ConnectionId { get; init; }
+    /// <summary>Gets the request timestamp.</summary>
+    public string? Timestamp { get; init; }
+    /// <summary>Gets the final request status.</summary>
+    public string? Status { get; init; }
+    /// <summary>Gets the timing object returned by 9Router.</summary>
+    public JsonElement? Latency { get; init; }
+    /// <summary>Gets the token counters returned by 9Router.</summary>
+    public NineRouterUsageTokens? Tokens { get; init; }
+}
+
+/// <summary>Token counters reported with an individual request.</summary>
+public sealed record NineRouterUsageTokens
+{
+    /// <summary>Gets prompt tokens, when reported in OpenAI format.</summary>
+    [JsonPropertyName("prompt_tokens")]
+    public long PromptTokens { get; init; }
+    /// <summary>Gets input tokens, when reported in Anthropic format.</summary>
+    [JsonPropertyName("input_tokens")]
+    public long InputTokens { get; init; }
+    /// <summary>Gets completion tokens, when reported in OpenAI format.</summary>
+    [JsonPropertyName("completion_tokens")]
+    public long CompletionTokens { get; init; }
+    /// <summary>Gets output tokens, when reported in Anthropic format.</summary>
+    [JsonPropertyName("output_tokens")]
+    public long OutputTokens { get; init; }
+    /// <summary>Gets cached tokens, when reported in OpenAI format.</summary>
+    [JsonPropertyName("cached_tokens")]
+    public long CachedTokens { get; init; }
+    /// <summary>Gets cache-read input tokens, when reported in Anthropic format.</summary>
+    [JsonPropertyName("cache_read_input_tokens")]
+    public long CacheReadInputTokens { get; init; }
+}
+
+/// <summary>Paged response returned by <c>GET /api/usage/request-details</c>.</summary>
+public sealed record NineRouterRequestDetailsPage
+{
+    /// <summary>Gets the requested page of redacted request metadata.</summary>
+    public List<NineRouterRequestDetail> Details { get; init; } = [];
+    /// <summary>Gets server-side paging information.</summary>
+    public NineRouterPagination Pagination { get; init; } = new();
+}
+
+/// <summary>Paging information returned by 9Router.</summary>
+public sealed record NineRouterPagination
+{
+    /// <summary>Gets the current one-based page.</summary>
+    public int Page { get; init; } = 1;
+    /// <summary>Gets the selected page size.</summary>
+    public int PageSize { get; init; }
+    /// <summary>Gets the total result count.</summary>
+    public int TotalItems { get; init; }
+    /// <summary>Gets the total page count.</summary>
+    public int TotalPages { get; init; }
+    /// <summary>Gets whether a next page exists.</summary>
+    public bool HasNext { get; init; }
+    /// <summary>Gets whether a previous page exists.</summary>
+    public bool HasPrev { get; init; }
+}
+
 /// <summary>9Router OAuth provider ids and flow helpers.</summary>
 public static class NineRouterOAuthProviders
 {

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -333,6 +333,57 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
+    public async Task UsageAsync_GetsStatsAndRedactedRequestDetails()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "totalRequests": 12,
+              "totalPromptTokens": 1000,
+              "totalCompletionTokens": 250,
+              "totalCachedTokens": 100,
+              "totalCost": 0.42,
+              "byProvider": { "openai": { "requests": 12, "promptTokens": 1000, "completionTokens": 250, "cachedTokens": 100, "cost": 0.42 } },
+              "activeRequests": [{ "provider": "openai", "model": "gpt-5", "account": "Primary", "count": 1 }]
+            }
+            """);
+        handler.EnqueueJson(HttpStatusCode.OK, """
+            {
+              "details": [{
+                "id": "request-1", "provider": "openai", "model": "gpt-5", "connectionId": "conn-1",
+                "timestamp": "2026-08-14T12:00:00.000Z", "status": "ok",
+                "latency": { "total": 125 },
+                "tokens": { "prompt_tokens": 100, "completion_tokens": 25 },
+                "request": { "redacted": true }
+              }],
+              "pagination": { "page": 2, "pageSize": 20, "totalItems": 21, "totalPages": 2, "hasNext": false, "hasPrev": true }
+            }
+            """);
+        using var client = new ApiClient(Port, handler);
+
+        var stats = await client.GetUsageStatsAsync("7d");
+        var details = await client.ListRequestDetailsAsync(page: 2, pageSize: 20);
+
+        Assert.Equal(12, stats.TotalRequests);
+        Assert.Equal(1_000, stats.TotalPromptTokens);
+        Assert.Equal(250, stats.TotalCompletionTokens);
+        Assert.Equal(0.42, stats.TotalCost);
+        Assert.Equal(12, stats.ByProvider["openai"].Requests);
+        Assert.Single(stats.ActiveRequests);
+        Assert.Equal("gpt-5", stats.ActiveRequests[0].Model);
+        Assert.Single(details.Details);
+        Assert.Equal("request-1", details.Details[0].Id);
+        Assert.Equal(100, details.Details[0].Tokens?.PromptTokens);
+        Assert.Equal(25, details.Details[0].Tokens?.CompletionTokens);
+        Assert.Equal(2, details.Pagination.Page);
+        Assert.Equal(21, details.Pagination.TotalItems);
+        Assert.Equal("/api/usage/stats", handler.Requests[0].Path);
+        Assert.Equal("?period=7d", handler.Requests[0].Query);
+        Assert.Equal("/api/usage/request-details", handler.Requests[1].Path);
+        Assert.Equal("?page=2&pageSize=20", handler.Requests[1].Query);
+    }
+
+    [Fact]
     public async Task ListProvidersAsync_401ThenLoginCookieThenRetry_Succeeds()
     {
         using var handler = new FakeApiHandler();


### PR DESCRIPTION
## Summary
- add a Home tab for 9Router usage with a stopped-engine notice
- fetch 9Router usage statistics and redacted request details
- cover the new management API endpoints with tests