### PR TITLE
feat: manage 9Router dashboard security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- **9Router dashboard security** (`ConfigurationView`, `MainWindowViewModel`, `NineRouter/ApiClient`): manage client API keys and the default agent key; require API keys for `/v1`; require dashboard login; and set a dashboard password that Tunnel Agent reuses for local management requests.
+
 ## [1.1.0] - 2026-08-15
 
 ### Added

--- a/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.es-ES.resx
@@ -1208,6 +1208,36 @@
     <value>Actualizar ahora</value>
   </data>
 
+  <data name="ConfigView_NineRouter_RequireLogin_Label" xml:space="preserve">
+    <value>Requerir inicio de sesión</value>
+  </data>
+  <data name="ConfigView_NineRouter_RequireLogin_Description" xml:space="preserve">
+    <value>Al activarlo, el panel requiere una contraseña.</value>
+  </data>
+  <data name="ConfigView_NineRouter_NewPassword_Label" xml:space="preserve">
+    <value>Nueva contraseña</value>
+  </data>
+  <data name="ConfigView_NineRouter_NewPassword_Placeholder" xml:space="preserve">
+    <value>Introduce la nueva contraseña</value>
+  </data>
+  <data name="ConfigView_NineRouter_ConfirmPassword_Label" xml:space="preserve">
+    <value>Confirmar nueva contraseña</value>
+  </data>
+  <data name="ConfigView_NineRouter_ConfirmPassword_Placeholder" xml:space="preserve">
+    <value>Confirma la nueva contraseña</value>
+  </data>
+  <data name="ConfigView_NineRouter_SetPassword" xml:space="preserve">
+    <value>Establecer contraseña</value>
+  </data>
+  <data name="ConfigView_NineRouter_RequireApiKey_Label" xml:space="preserve">
+    <value>Requerir clave de API</value>
+  </data>
+  <data name="ConfigView_NineRouter_RequireApiKey_Description" xml:space="preserve">
+    <value>Se rechazarán las solicitudes sin una clave válida.</value>
+  </data>
+  <data name="ConfigView_NineRouter_ApiKeys_Description" xml:space="preserve">
+    <value>Claves aceptadas por los clientes de 9Router. La configuración del agente usa la clave predeterminada.</value>
+  </data>
   <data name="ConfigView_NineRouter_EngineFolder_Label" xml:space="preserve">
     <value>Carpeta de instalación del motor</value>
   </data>
@@ -1390,6 +1420,15 @@
   </data>
   <data name="AgentConfigOverlay_DoneButton" xml:space="preserve">
     <value>Hecho</value>
+  </data>
+  <data name="ApiKeysOverlay_NineRouter_Title" xml:space="preserve">
+    <value>Claves de 9Router</value>
+  </data>
+  <data name="ApiKeysOverlay_NineRouter_Description" xml:space="preserve">
+    <value>Claves aceptadas por los clientes de 9Router. La configuración del agente usa la clave predeterminada.</value>
+  </data>
+  <data name="ApiKeysOverlay_NineRouter_AddKeyLabel" xml:space="preserve">
+    <value>Nombre de la clave</value>
   </data>
   <data name="ApiKeysOverlay_Title" xml:space="preserve">
     <value>Claves de CLIProxyAPI</value>

--- a/src/TunnelAgent.Avalonia/Resources/Strings.resx
+++ b/src/TunnelAgent.Avalonia/Resources/Strings.resx
@@ -1258,6 +1258,36 @@
     <value>Update now</value>
   </data>
 
+  <data name="ConfigView_NineRouter_RequireLogin_Label" xml:space="preserve">
+    <value>Require login</value>
+  </data>
+  <data name="ConfigView_NineRouter_RequireLogin_Description" xml:space="preserve">
+    <value>When on, the dashboard requires a password.</value>
+  </data>
+  <data name="ConfigView_NineRouter_NewPassword_Label" xml:space="preserve">
+    <value>New password</value>
+  </data>
+  <data name="ConfigView_NineRouter_NewPassword_Placeholder" xml:space="preserve">
+    <value>Enter new password</value>
+  </data>
+  <data name="ConfigView_NineRouter_ConfirmPassword_Label" xml:space="preserve">
+    <value>Confirm new password</value>
+  </data>
+  <data name="ConfigView_NineRouter_ConfirmPassword_Placeholder" xml:space="preserve">
+    <value>Confirm new password</value>
+  </data>
+  <data name="ConfigView_NineRouter_SetPassword" xml:space="preserve">
+    <value>Set password</value>
+  </data>
+  <data name="ConfigView_NineRouter_RequireApiKey_Label" xml:space="preserve">
+    <value>Require API key</value>
+  </data>
+  <data name="ConfigView_NineRouter_RequireApiKey_Description" xml:space="preserve">
+    <value>Requests without a valid key will be rejected.</value>
+  </data>
+  <data name="ConfigView_NineRouter_ApiKeys_Description" xml:space="preserve">
+    <value>Keys accepted by 9Router clients. Agent setup uses the default key.</value>
+  </data>
   <data name="ConfigView_NineRouter_EngineFolder_Label" xml:space="preserve">
     <value>Engine install folder</value>
   </data>
@@ -1442,6 +1472,15 @@
   </data>
   <data name="AgentConfigOverlay_DoneButton" xml:space="preserve">
     <value>Done</value>
+  </data>
+  <data name="ApiKeysOverlay_NineRouter_Title" xml:space="preserve">
+    <value>9Router keys</value>
+  </data>
+  <data name="ApiKeysOverlay_NineRouter_Description" xml:space="preserve">
+    <value>Keys accepted by 9Router clients. Agent setup uses the default key.</value>
+  </data>
+  <data name="ApiKeysOverlay_NineRouter_AddKeyLabel" xml:space="preserve">
+    <value>Key name</value>
   </data>
   <data name="ApiKeysOverlay_Title" xml:space="preserve">
     <value>CLIProxyAPI keys</value>

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -16,6 +16,7 @@ using TunnelAgent.Infrastructure.Engine;
 using TunnelAgent.Infrastructure.Engine.CliProxy;
 using TunnelAgent.Infrastructure.Engine.Perplexity;
 using TunnelAgent.Infrastructure.Engine.NineRouter;
+using TunnelAgent.Infrastructure.Services;
 
 namespace TunnelAgent.ViewModels;
 
@@ -23,14 +24,17 @@ namespace TunnelAgent.ViewModels;
 public sealed record AgentConfigItemResult(
     string AgentName, bool Success, string? Error, string? ConfigPath);
 
-public sealed record CliProxyApiKeyViewModel(string Value, bool IsDefault)
+public sealed record ApiKeyViewModel(string Value, string? Id, string? Name, bool IsDefault)
 {
     public string Masked => string.IsNullOrEmpty(Value)
         ? ""
         : Value.Length > 12 ? $"{Value[..8]}...{Value[^4..]}" : Value;
-    public bool CanRemove => true;
+    public bool HasName => !string.IsNullOrWhiteSpace(Name);
+    public bool CanRemove => Id is null || !string.IsNullOrWhiteSpace(Id);
     public bool CanSetDefault => !IsDefault;
 }
+
+internal enum ApiKeyTarget { CliProxy, NineRouter }
 
 internal sealed record PendingNineRouterOAuth(
     NineRouterProviderOption Provider,
@@ -257,6 +261,27 @@ SelectedSection is SectionKey.Logs;
     [ObservableProperty] private bool _showNineRouterOAuthCodeDialog;
     [ObservableProperty] private string _nineRouterOAuthCodeDraft = "";
     [ObservableProperty] private bool _isNineRouterBusy;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowNineRouterPasswordSettings))]
+    private bool _nineRouterRequireLogin;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanChangeNineRouterRequireLogin))]
+    private bool _isUpdatingNineRouterRequireLogin;
+    private bool _suppressNineRouterRequireLoginUpdate;
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SetNineRouterDashboardPasswordCommand))]
+    private string _nineRouterNewPasswordDraft = "";
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SetNineRouterDashboardPasswordCommand))]
+    private string _nineRouterConfirmPasswordDraft = "";
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(SetNineRouterDashboardPasswordCommand))]
+    private bool _isSettingNineRouterDashboardPassword;
+    [ObservableProperty] private bool _nineRouterRequireApiKey;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanChangeNineRouterRequireApiKey))]
+    private bool _isUpdatingNineRouterRequireApiKey;
+    private bool _suppressNineRouterRequireApiKeyUpdate;
     private PendingNineRouterOAuth? _pendingNineRouterOAuth;
 
     [ObservableProperty] private bool _showOAuthStatus;
@@ -337,6 +362,7 @@ SelectedSection is SectionKey.Logs;
     [ObservableProperty] private bool _showApiKeysDialog;
     [ObservableProperty] private string _apiKeyDraft = "";
     [ObservableProperty] private bool _showApiKeyDraft;
+    private ApiKeyTarget _apiKeyTarget;
     [ObservableProperty] private string _addAccountApiKeyDraft = "";
     [ObservableProperty] private string _addAccountBaseUrlDraft = "";
     [ObservableProperty]
@@ -428,7 +454,7 @@ SelectedSection is SectionKey.Logs;
     public ObservableCollection<AvailableModelGroupViewModel> PerplexityModelGroups { get; }
     public ObservableCollection<AvailableModelGroupViewModel> NineRouterModelGroups { get; }
     public ObservableCollection<EngineOptionViewModel> EngineOptions { get; } = new();
-    public ObservableCollection<CliProxyApiKeyViewModel> CliProxyApiKeys { get; } = new();
+    public ObservableCollection<ApiKeyViewModel> ApiKeys { get; } = new();
     public ObservableCollection<SelectableModelViewModel> SelectableModels { get; } = new();
     private bool _suppressSelectableModelState;
     public ObservableCollection<SelectableModelViewModel> CustomProviderModels { get; } = new();
@@ -683,6 +709,9 @@ SelectedSection is SectionKey.Logs;
     public string PerplexityEmptyStateText => "Perplexity needs at least one saved WebUI session token account.";
     public bool HasNineRouterConnections => NineRouterConnections.Count > 0;
     public bool IsNineRouterEngineRunning => NineRouterEngine.State == EngineState.Running;
+    public bool ShowNineRouterPasswordSettings => NineRouterRequireLogin;
+    public bool CanChangeNineRouterRequireLogin => IsNineRouterEngineRunning && !IsUpdatingNineRouterRequireLogin;
+    public bool CanChangeNineRouterRequireApiKey => IsNineRouterEngineRunning && !IsUpdatingNineRouterRequireApiKey;
     public string AuthFilesDescription => IsNineRouterEngineSelected
         ? _localization.GetString("ProvidersView_NineRouterSection_AuthFiles")
         : IsPerplexityEngineSelected
@@ -822,6 +851,9 @@ SelectedSection is SectionKey.Logs;
                 OnPropertyChanged(nameof(AgentConfigDialogTitle));
                 OnPropertyChanged(nameof(AgentConfigDialogDescription));
                 OnPropertyChanged(nameof(ModelsExpanderLabel));
+                OnPropertyChanged(nameof(ApiKeysDialogTitle));
+                OnPropertyChanged(nameof(ApiKeysDialogDescription));
+                OnPropertyChanged(nameof(ApiKeyDraftLabel));
                 OnPropertyChanged(nameof(SelectedEngineVersionDescription));
                 OnPropertyChanged(nameof(InstalledEngineHashLabel));
                 foreach (var mode in ThemeModes)
@@ -1572,7 +1604,7 @@ SelectedSection is SectionKey.Logs;
     {
         try
         {
-            using var client = new ApiClient(engine.Port);
+            using var client = ApiClient.CreateDashboardClient(engine.Port);
             var connections = await client.ListProvidersAsync(token);
             var settings = await client.GetSettingsAsync(token);
             await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections, settings));
@@ -1665,6 +1697,9 @@ SelectedSection is SectionKey.Logs;
         OnPropertyChanged(nameof(NineRouterEndpointUrl));
         OnPropertyChanged(nameof(NineRouterDashboardUrl));
         OnPropertyChanged(nameof(IsNineRouterEngineRunning));
+        OnPropertyChanged(nameof(CanChangeNineRouterRequireLogin));
+        OnPropertyChanged(nameof(CanChangeNineRouterRequireApiKey));
+        SetNineRouterDashboardPasswordCommand.NotifyCanExecuteChanged();
         OnPropertyChanged(nameof(ShowNineRouterUsage));
         OnPropertyChanged(nameof(ShowNineRouterUsageWarning));
         NineRouterUsage.NotifyEngineStateChanged();
@@ -2707,7 +2742,7 @@ SelectedSection is SectionKey.Logs;
         IsNineRouterBusy = true;
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             using var timeoutCts = new CancellationTokenSource(NineRouterOAuthProviders.DefaultTimeout);
 
             if (provider.OAuthFlow == NineRouterOAuthFlow.DeviceCode)
@@ -2778,7 +2813,7 @@ SelectedSection is SectionKey.Logs;
         try
         {
             var code = ExtractNineRouterOAuthCode(input, pending.Start.State);
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             await client.ExchangeOAuthAsync(
                 pending.Provider.Id,
                 code,
@@ -2836,7 +2871,7 @@ SelectedSection is SectionKey.Logs;
         IsNineRouterBusy = true;
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             foreach (var account in provider.Accounts)
             {
                 await client.UpdateProviderAsync(
@@ -2887,7 +2922,7 @@ SelectedSection is SectionKey.Logs;
         IsNineRouterBusy = true;
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             await client.UpdateProviderAsync(connection.Id, new NineRouterUpdateProviderRequest { Name = name });
             DismissEditNineRouterConnectionNameDialog();
             await RefreshNineRouterConnectionsAsync();
@@ -2909,7 +2944,7 @@ SelectedSection is SectionKey.Logs;
         IsNineRouterBusy = true;
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             var settings = await client.GetSettingsAsync();
             var strategies = new Dictionary<string, NineRouterProviderStrategy>(
                 settings.ProviderStrategies ?? [],
@@ -2943,7 +2978,7 @@ SelectedSection is SectionKey.Logs;
         IsNineRouterBusy = true;
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             await client.UpdateProviderAsync(
                 connection.Id,
                 new NineRouterUpdateProviderRequest { IsActive = !connection.IsActive });
@@ -2966,7 +3001,7 @@ SelectedSection is SectionKey.Logs;
         IsNineRouterBusy = true;
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             await client.DeleteProviderAsync(connection.Id);
             await RefreshNineRouterConnectionsAsync();
             RestartNineRouterModelFetch();
@@ -3014,7 +3049,7 @@ SelectedSection is SectionKey.Logs;
 
     private async Task PostNineRouterProviderAsync(string providerId, string name, string apiKey, string authType = "apikey")
     {
-        using var client = new ApiClient(NineRouterEngine.Port);
+        using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
         await client.CreateProviderAsync(new NineRouterCreateProviderRequest
         {
             Provider = providerId,
@@ -3043,7 +3078,7 @@ SelectedSection is SectionKey.Logs;
 
         try
         {
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             var connections = await client.ListProvidersAsync();
             var settings = await client.GetSettingsAsync();
             await Dispatcher.UIThread.InvokeAsync(() => ApplyNineRouterConnections(connections, settings));
@@ -3059,6 +3094,8 @@ SelectedSection is SectionKey.Logs;
 
     private void ApplyNineRouterConnections(IReadOnlyList<NineRouterProvider> connections, NineRouterSettings settings)
     {
+        SetNineRouterRequireLogin(settings.RequireLogin);
+        SetNineRouterRequireApiKey(settings.RequireApiKey);
         var strategies = settings.ProviderStrategies ?? [];
         var providers = NineRouterProviderCatalog.All
             .Select(option => new NineRouterProviderViewModel(
@@ -3118,7 +3155,7 @@ SelectedSection is SectionKey.Logs;
         try
         {
             await RefreshNineRouterConnectionsAsync();
-            using var client = new ApiClient(NineRouterEngine.Port);
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
             foreach (var connection in NineRouterConnections)
                 await RefreshNineRouterUsageAsync(connection, client);
         }
@@ -3133,7 +3170,7 @@ SelectedSection is SectionKey.Logs;
         ArgumentNullException.ThrowIfNull(connection);
         if (NineRouterEngine.State != EngineState.Running || connection.IsUsageRefreshing) return;
 
-        using var client = new ApiClient(NineRouterEngine.Port);
+        using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
         await RefreshNineRouterUsageAsync(connection, client);
     }
 
@@ -3244,6 +3281,112 @@ SelectedSection is SectionKey.Logs;
         _nineRouterModelFetchCts?.Cancel();
         _nineRouterModelFetchCts = null;
         StartNineRouterModelFetch(NineRouterEngine);
+    }
+
+    partial void OnNineRouterRequireLoginChanged(bool value)
+    {
+        if (!value)
+        {
+            NineRouterNewPasswordDraft = "";
+            NineRouterConfirmPasswordDraft = "";
+        }
+        if (!_suppressNineRouterRequireLoginUpdate && CanChangeNineRouterRequireLogin)
+            _ = UpdateNineRouterRequireLoginAsync(value);
+    }
+
+    private void SetNineRouterRequireLogin(bool value)
+    {
+        _suppressNineRouterRequireLoginUpdate = true;
+        NineRouterRequireLogin = value;
+        _suppressNineRouterRequireLoginUpdate = false;
+    }
+
+    private async Task UpdateNineRouterRequireLoginAsync(bool value)
+    {
+        IsUpdatingNineRouterRequireLogin = true;
+        try
+        {
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
+            var settings = await client.UpdateDashboardSecurityAsync(requireLogin: value);
+            SetNineRouterRequireLogin(settings.RequireLogin);
+        }
+        catch (Exception ex)
+        {
+            SetNineRouterRequireLogin(!value);
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            IsUpdatingNineRouterRequireLogin = false;
+        }
+    }
+
+    private bool CanSetNineRouterDashboardPassword() =>
+        CanChangeNineRouterRequireLogin &&
+        !IsSettingNineRouterDashboardPassword &&
+        !string.IsNullOrWhiteSpace(NineRouterNewPasswordDraft) &&
+        string.Equals(NineRouterNewPasswordDraft, NineRouterConfirmPasswordDraft, StringComparison.Ordinal);
+
+    [RelayCommand(CanExecute = nameof(CanSetNineRouterDashboardPassword))]
+    private async Task SetNineRouterDashboardPasswordAsync()
+    {
+        var password = NineRouterNewPasswordDraft;
+        IsSettingNineRouterDashboardPassword = true;
+        try
+        {
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
+            var settings = await client.UpdateDashboardSecurityAsync(
+                currentPassword: ApiClient.DashboardPassword,
+                newPassword: password);
+            await Task.Run(() => UserEnvironmentService.Set(ApiClient.DashboardPasswordEnvVarName, password));
+            SetNineRouterRequireLogin(settings.RequireLogin);
+        }
+        catch (Exception ex)
+        {
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            NineRouterNewPasswordDraft = "";
+            NineRouterConfirmPasswordDraft = "";
+            IsSettingNineRouterDashboardPassword = false;
+        }
+    }
+
+    partial void OnNineRouterRequireApiKeyChanged(bool value)
+    {
+        if (!_suppressNineRouterRequireApiKeyUpdate && CanChangeNineRouterRequireApiKey)
+            _ = UpdateNineRouterRequireApiKeyAsync(value);
+    }
+
+    private void SetNineRouterRequireApiKey(bool value)
+    {
+        _suppressNineRouterRequireApiKeyUpdate = true;
+        NineRouterRequireApiKey = value;
+        _suppressNineRouterRequireApiKeyUpdate = false;
+    }
+
+    private async Task UpdateNineRouterRequireApiKeyAsync(bool value)
+    {
+        IsUpdatingNineRouterRequireApiKey = true;
+        try
+        {
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
+            var settings = await client.UpdateSettingsAsync(new NineRouterUpdateSettingsRequest
+            {
+                RequireApiKey = value
+            });
+            SetNineRouterRequireApiKey(settings.RequireApiKey);
+        }
+        catch (Exception ex)
+        {
+            SetNineRouterRequireApiKey(!value);
+            ShowNineRouterStatus(ex.Message, isError: true);
+        }
+        finally
+        {
+            IsUpdatingNineRouterRequireApiKey = false;
+        }
     }
 
     private void ShowNineRouterStatus(string message, bool isError)
@@ -3961,11 +4104,20 @@ SelectedSection is SectionKey.Logs;
         RefreshApiKeyItems();
     }
 
-    private void RefreshApiKeyItems() => _ = RefreshApiKeyItemsAsync();
+    private void RefreshApiKeyItems() => _ = RefreshCliProxyApiKeyItemsAsync();
 
-    private async Task RefreshApiKeyItemsAsync()
+    public string ApiKeysDialogTitle => _localization.GetString(_apiKeyTarget == ApiKeyTarget.NineRouter
+        ? "ApiKeysOverlay_NineRouter_Title" : "ApiKeysOverlay_Title");
+    public string ApiKeysDialogDescription => _localization.GetString(_apiKeyTarget == ApiKeyTarget.NineRouter
+        ? "ApiKeysOverlay_NineRouter_Description" : "ApiKeysOverlay_Description");
+    public string ApiKeyDraftLabel => _localization.GetString(_apiKeyTarget == ApiKeyTarget.NineRouter
+        ? "ApiKeysOverlay_NineRouter_AddKeyLabel" : "ApiKeysOverlay_AddKeyLabel");
+    public string ApiKeyDraftWatermark => _apiKeyTarget == ApiKeyTarget.NineRouter ? "Tunnel Agent" : "sk-...";
+    public bool IsApiKeyDraftSecret => _apiKeyTarget != ApiKeyTarget.NineRouter;
+
+    private async Task RefreshCliProxyApiKeyItemsAsync()
     {
-        var keys   = await _configService.ReadApiKeysFromConfigAsync();
+        var keys = await _configService.ReadApiKeysFromConfigAsync();
         var defKey = TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get("TUNNEL_AGENT_CLIPROXY_API_KEY") ?? "";
 
         // If env var has a key not in yaml, add it so both stay in sync.
@@ -3983,20 +4135,63 @@ SelectedSection is SectionKey.Logs;
             await SyncCliProxyEnvVarAsync(defKey);
         }
 
-        CliProxyApiKeys.Clear();
+        if (_apiKeyTarget != ApiKeyTarget.CliProxy) return;
+        ApiKeys.Clear();
         foreach (var key in keys)
-            CliProxyApiKeys.Add(new CliProxyApiKeyViewModel(key,
+            ApiKeys.Add(new ApiKeyViewModel(key, null, null,
                 string.Equals(key, defKey, StringComparison.Ordinal)));
         OnPropertyChanged(nameof(CurrentAgentApiKey));
+    }
+
+    private async Task RefreshNineRouterApiKeyItemsAsync()
+    {
+        if (NineRouterEngine.State != EngineState.Running || _apiKeyTarget != ApiKeyTarget.NineRouter)
+            return;
+
+        using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
+        var keys = await client.ListKeysAsync();
+        var defKey = TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get(NineRouterClientKeyService.EnvVarName) ?? "";
+        ApiKeys.Clear();
+        foreach (var key in keys)
+            ApiKeys.Add(new ApiKeyViewModel(key.Key ?? "", key.Id, key.Name,
+                string.Equals(key.Key, defKey, StringComparison.Ordinal)));
     }
 
     [RelayCommand]
     private void OpenApiKeys()
     {
+        _apiKeyTarget = ApiKeyTarget.CliProxy;
+        RefreshApiKeyDialogProperties();
         RefreshApiKeyItems();
         ApiKeyDraft = "";
         ShowApiKeyDraft = false;
         ShowApiKeysDialog = true;
+    }
+
+    [RelayCommand]
+    private void OpenNineRouterApiKeys()
+    {
+        if (NineRouterEngine.State != EngineState.Running)
+        {
+            ShowNineRouterStatus(_localization.GetString("ProvidersView_NineRouter_EngineNotRunning"), isError: true);
+            return;
+        }
+
+        _apiKeyTarget = ApiKeyTarget.NineRouter;
+        RefreshApiKeyDialogProperties();
+        ApiKeyDraft = "";
+        ShowApiKeyDraft = false;
+        ShowApiKeysDialog = true;
+        _ = RefreshNineRouterApiKeyItemsAsync();
+    }
+
+    private void RefreshApiKeyDialogProperties()
+    {
+        OnPropertyChanged(nameof(ApiKeysDialogTitle));
+        OnPropertyChanged(nameof(ApiKeysDialogDescription));
+        OnPropertyChanged(nameof(ApiKeyDraftLabel));
+        OnPropertyChanged(nameof(ApiKeyDraftWatermark));
+        OnPropertyChanged(nameof(IsApiKeyDraftSecret));
     }
 
     [RelayCommand]
@@ -4010,34 +4205,71 @@ SelectedSection is SectionKey.Logs;
     [RelayCommand]
     private async Task AddApiKeyAsync()
     {
-        var key = ApiKeyDraft.Trim();
-        if (string.IsNullOrWhiteSpace(key)) return;
+        var value = ApiKeyDraft.Trim();
+        if (string.IsNullOrWhiteSpace(value)) return;
         ApiKeyDraft = "";
         ShowApiKeyDraft = false;
-        var isFirst = !CliProxyApiKeys.Any() || string.IsNullOrWhiteSpace(TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get("TUNNEL_AGENT_CLIPROXY_API_KEY"));
-        await PersistApiKeysAsync(key, setDefault: isFirst);
+
+        if (_apiKeyTarget == ApiKeyTarget.NineRouter)
+        {
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
+            var created = await client.CreateKeyAsync(value);
+            if (string.IsNullOrWhiteSpace(TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get(NineRouterClientKeyService.EnvVarName)))
+                await SyncNineRouterEnvVarAsync(created.Key ?? "");
+            await RefreshNineRouterApiKeyItemsAsync();
+            return;
+        }
+
+        var isFirst = !ApiKeys.Any() || string.IsNullOrWhiteSpace(TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get("TUNNEL_AGENT_CLIPROXY_API_KEY"));
+        await PersistApiKeysAsync(value, setDefault: isFirst);
     }
 
     [RelayCommand]
-    private async Task RemoveApiKeyAsync(CliProxyApiKeyViewModel? key)
+    private async Task RemoveApiKeyAsync(ApiKeyViewModel? key)
     {
         if (key is null) return;
+
+        if (_apiKeyTarget == ApiKeyTarget.NineRouter)
+        {
+            if (string.IsNullOrWhiteSpace(key.Id)) return;
+            var wasDefault = key.IsDefault;
+            using var client = ApiClient.CreateDashboardClient(NineRouterEngine.Port);
+            await client.DeleteKeyAsync(key.Id);
+            if (wasDefault)
+                await SyncNineRouterEnvVarAsync("");
+            await RefreshNineRouterApiKeyItemsAsync();
+            if (wasDefault)
+            {
+                var replacement = ApiKeys.FirstOrDefault(item => !string.IsNullOrWhiteSpace(item.Value));
+                await SyncNineRouterEnvVarAsync(replacement?.Value ?? "");
+                await RefreshNineRouterApiKeyItemsAsync();
+            }
+            return;
+        }
+
         var keys = await _configService.ReadApiKeysFromConfigAsync();
         keys.RemoveAll(k => string.Equals(k, key.Value, StringComparison.Ordinal));
         await _configService.WriteApiKeysToConfigAsync(keys);
-        // Update default env var if removed key was the default
+        // Update default env var if removed key was the default.
         var defKey = TunnelAgent.Infrastructure.Services.UserEnvironmentService.Get("TUNNEL_AGENT_CLIPROXY_API_KEY") ?? "";
         if (string.Equals(defKey, key.Value, StringComparison.Ordinal))
             await SyncCliProxyEnvVarAsync(keys.FirstOrDefault() ?? "");
-        await RefreshApiKeyItemsAsync();
+        await RefreshCliProxyApiKeyItemsAsync();
     }
 
     [RelayCommand]
-    private async Task SetDefaultApiKeyAsync(CliProxyApiKeyViewModel? key)
+    private async Task SetDefaultApiKeyAsync(ApiKeyViewModel? key)
     {
         if (key is null) return;
+        if (_apiKeyTarget == ApiKeyTarget.NineRouter)
+        {
+            await SyncNineRouterEnvVarAsync(key.Value);
+            await RefreshNineRouterApiKeyItemsAsync();
+            return;
+        }
+
         await SyncCliProxyEnvVarAsync(key.Value);
-        await RefreshApiKeyItemsAsync();
+        await RefreshCliProxyApiKeyItemsAsync();
     }
 
     private async Task PersistApiKeysAsync(string newKey, bool setDefault)
@@ -4047,7 +4279,7 @@ SelectedSection is SectionKey.Logs;
             keys.Add(newKey);
         await _configService.WriteApiKeysToConfigAsync(keys);
         if (setDefault) await SyncCliProxyEnvVarAsync(newKey);
-        await RefreshApiKeyItemsAsync();
+        await RefreshCliProxyApiKeyItemsAsync();
         await CliProxyEngine.WriteConfigAsync();
     }
 
@@ -4057,6 +4289,14 @@ SelectedSection is SectionKey.Logs;
             TunnelAgent.Infrastructure.Services.UserEnvironmentService.Set("TUNNEL_AGENT_CLIPROXY_API_KEY", key);
         else
             TunnelAgent.Infrastructure.Services.UserEnvironmentService.Remove("TUNNEL_AGENT_CLIPROXY_API_KEY");
+    });
+
+    private static Task SyncNineRouterEnvVarAsync(string key) => Task.Run(() =>
+    {
+        if (!string.IsNullOrWhiteSpace(key))
+            TunnelAgent.Infrastructure.Services.UserEnvironmentService.Set(NineRouterClientKeyService.EnvVarName, key);
+        else
+            TunnelAgent.Infrastructure.Services.UserEnvironmentService.Remove(NineRouterClientKeyService.EnvVarName);
     });
 
     public int LocalProxyScrollRequestId { get; private set; }

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterCombosViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterCombosViewModel.cs
@@ -191,7 +191,7 @@ public sealed partial class NineRouterCombosViewModel : ObservableObject
         ErrorMessage = null;
         try
         {
-            using var client = new ApiClient(_port());
+            using var client = ApiClient.CreateDashboardClient(_port());
             var combos = await client.ListCombosAsync();
             var settings = await client.GetSettingsAsync();
             Combos.Clear();
@@ -300,7 +300,7 @@ public sealed partial class NineRouterCombosViewModel : ObservableObject
             var strategy = DraftStrategy;
             var judgeModel = DraftJudgeModel;
             var previousName = _editingComboName;
-            using var client = new ApiClient(_port());
+            using var client = ApiClient.CreateDashboardClient(_port());
             if (_editingComboId is null)
                 await client.CreateComboAsync(new NineRouterCreateComboRequest { Name = name, Models = [.. DraftModels] });
             else
@@ -338,7 +338,7 @@ public sealed partial class NineRouterCombosViewModel : ObservableObject
         ErrorMessage = null;
         try
         {
-            using var client = new ApiClient(_port());
+            using var client = ApiClient.CreateDashboardClient(_port());
             await client.DeleteComboAsync(combo.Id);
             var settings = await client.GetSettingsAsync();
             if (settings.ComboStrategies.Remove(combo.Name))

--- a/src/TunnelAgent.Avalonia/ViewModels/NineRouterUsageViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/NineRouterUsageViewModel.cs
@@ -135,7 +135,7 @@ public sealed partial class NineRouterUsageViewModel : ViewModelBase
         ErrorMessage = null;
         try
         {
-            using var client = new ApiClient(_port());
+            using var client = ApiClient.CreateDashboardClient(_port());
             var stats = await client.GetUsageStatsAsync("7d");
             var details = await client.ListRequestDetailsAsync(CurrentPage, PageSize);
             Apply(stats, details);

--- a/src/TunnelAgent.Avalonia/Views/ApiKeysOverlayView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ApiKeysOverlayView.axaml
@@ -20,9 +20,9 @@
         <Grid RowDefinitions="Auto,*,Auto">
             <Grid Grid.Row="0" Margin="24,20,24,14" ColumnDefinitions="*,Auto">
                 <StackPanel Grid.Column="0" Spacing="4">
-                    <TextBlock Classes="row-label" FontSize="15" Text="{l:Loc ApiKeysOverlay_Title}" />
+                    <TextBlock Classes="row-label" FontSize="15" Text="{Binding ApiKeysDialogTitle}" />
                     <TextBlock Classes="row-desc" TextWrapping="Wrap"
-                               Text="{l:Loc ApiKeysOverlay_Description}" />
+                               Text="{Binding ApiKeysDialogDescription}" />
                 </StackPanel>
                 <Button Grid.Column="1" Classes="icon" Command="{Binding DismissApiKeysCommand}" VerticalAlignment="Top">
                     <lucide:PackIconLucide Kind="X" Width="14" Height="14" />
@@ -30,12 +30,14 @@
             </Grid>
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
                 <StackPanel Spacing="12" Margin="24,0,24,0">
-                    <ItemsControl ItemsSource="{Binding CliProxyApiKeys}">
+                    <ItemsControl ItemsSource="{Binding ApiKeys}">
                         <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="vm:CliProxyApiKeyViewModel">
+                            <DataTemplate x:DataType="vm:ApiKeyViewModel">
                                 <Border Background="{DynamicResource SideBgBrush}" CornerRadius="8" Padding="10,8" Margin="0,0,0,6">
                                     <Grid ColumnDefinitions="*,Auto,Auto,Auto">
                                         <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="8" VerticalAlignment="Center">
+                                            <TextBlock Text="{Binding Name}" IsVisible="{Binding HasName}"
+                                                       FontSize="12" VerticalAlignment="Center" />
                                             <TextBlock Text="{Binding Masked}"
                                                        FontFamily="Cascadia Mono,Consolas,monospace"
                                                        FontSize="12" VerticalAlignment="Center" />
@@ -65,15 +67,16 @@
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
                     <StackPanel Spacing="4">
-                        <TextBlock Classes="row-desc" Text="{l:Loc ApiKeysOverlay_AddKeyLabel}" />
+                        <TextBlock Classes="row-desc" Text="{Binding ApiKeyDraftLabel}" />
                         <Grid ColumnDefinitions="*,Auto">
                             <TextBox Grid.Column="0" Classes="app"
-                                     PasswordChar="{Binding ShowApiKeyDraft, Converter={StaticResource SecretPasswordChar}}"
-                                     Watermark="sk-..."
+                                     PasswordChar="{Binding IsApiKeyDraftSecret, Converter={StaticResource SecretPasswordChar}}"
+                                     Watermark="{Binding ApiKeyDraftWatermark}"
                                      Text="{Binding ApiKeyDraft, Mode=TwoWay}"
                                      KeyDown="OnApiKeyDraftKeyDown" />
                             <Button Grid.Column="1" Classes="icon-btn" Margin="8,0,0,0"
                                     ToolTip.Tip="{l:Loc ApiKeysOverlay_ShowHideKeyTooltip}"
+                                    IsVisible="{Binding IsApiKeyDraftSecret}"
                                     Command="{Binding ToggleApiKeyDraftVisibilityCommand}">
                                 <lucide:PackIconLucide Kind="{Binding ShowApiKeyDraft, Converter={StaticResource EyeIcon}}" Width="14" Height="14" />
                             </Button>

--- a/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/ConfigurationView.axaml
@@ -764,6 +764,59 @@
                             <Border Classes="row-divider"/>
                             <Grid Margin="14,11" ColumnDefinitions="*,Auto">
                                 <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_RequireLogin_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_RequireLogin_Description}"/>
+                                </StackPanel>
+                                <ToggleButton Grid.Column="1" Classes="enable-toggle"
+                                              IsChecked="{Binding NineRouterRequireLogin, Mode=TwoWay}"
+                                              IsEnabled="{Binding CanChangeNineRouterRequireLogin}" />
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <StackPanel Margin="14,11" Spacing="8"
+                                        IsVisible="{Binding ShowNineRouterPasswordSettings}">
+                                <Grid ColumnDefinitions="*,*" ColumnSpacing="12">
+                                    <StackPanel Spacing="4">
+                                        <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_NewPassword_Label}"/>
+                                        <TextBox Classes="app" PasswordChar="●"
+                                                 Watermark="{l:Loc ConfigView_NineRouter_NewPassword_Placeholder}"
+                                                 Text="{Binding NineRouterNewPasswordDraft, Mode=TwoWay}" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="1" Spacing="4">
+                                        <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_ConfirmPassword_Label}"/>
+                                        <TextBox Classes="app" PasswordChar="●"
+                                                 Watermark="{l:Loc ConfigView_NineRouter_ConfirmPassword_Placeholder}"
+                                                 Text="{Binding NineRouterConfirmPasswordDraft, Mode=TwoWay}" />
+                                    </StackPanel>
+                                </Grid>
+                                <Button Classes="app primary" HorizontalAlignment="Left"
+                                        Content="{l:Loc ConfigView_NineRouter_SetPassword}"
+                                        Command="{Binding SetNineRouterDashboardPasswordCommand}"
+                                        IsEnabled="{Binding CanSetNineRouterDashboardPassword}" />
+                            </StackPanel>
+                            <Border Classes="row-divider"
+                                    IsVisible="{Binding ShowNineRouterPasswordSettings}"/>
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_RequireApiKey_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_RequireApiKey_Description}"/>
+                                </StackPanel>
+                                <ToggleButton Grid.Column="1" Classes="enable-toggle"
+                                              IsChecked="{Binding NineRouterRequireApiKey, Mode=TwoWay}"
+                                              IsEnabled="{Binding CanChangeNineRouterRequireApiKey}" />
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
+                                    <TextBlock Classes="row-label" Text="{l:Loc ConfigView_CLIProxy_ApiKeys_Label}"/>
+                                    <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_ApiKeys_Description}"/>
+                                </StackPanel>
+                                <Button Grid.Column="1" Classes="app" Content="{l:Loc ConfigView_CLIProxy_ApiKeys_Manage}"
+                                        Command="{Binding OpenNineRouterApiKeysCommand}"
+                                        IsEnabled="{Binding IsNineRouterEngineRunning}" />
+                            </Grid>
+                            <Border Classes="row-divider"/>
+                            <Grid Margin="14,11" ColumnDefinitions="*,Auto">
+                                <StackPanel>
                                     <TextBlock Classes="row-label" Text="{l:Loc ConfigView_NineRouter_Dashboard_Label}"/>
                                     <TextBlock Classes="row-desc" Text="{l:Loc ConfigView_NineRouter_Dashboard_Description}"/>
                                     <TextBlock Classes="row-desc" Text="{Binding NineRouterDashboardUrl}" />

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiClient.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using TunnelAgent.Infrastructure.Services;
 
 namespace TunnelAgent.Infrastructure.Engine.NineRouter;
 
@@ -30,6 +31,9 @@ public sealed class ApiClient : IDisposable
 
     /// <summary>9Router's password before the user changes it in the dashboard.</summary>
     public const string DefaultDashboardPassword = "123456";
+
+    /// <summary>User-environment variable that stores the local 9Router dashboard password.</summary>
+    public const string DashboardPasswordEnvVarName = "TUNNEL_AGENT_9ROUTER_DASHBOARD_PASSWORD";
 
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
@@ -88,6 +92,15 @@ public sealed class ApiClient : IDisposable
         if (_http.DefaultRequestHeaders.UserAgent.Count == 0)
             _http.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("TunnelAgent", TunnelAgent.AppVersion.Current));
     }
+
+    /// <summary>Creates a client with Tunnel Agent's saved dashboard password.</summary>
+    public static ApiClient CreateDashboardClient(int port) => new(
+        port,
+        UserEnvironmentService.Get(DashboardPasswordEnvVarName) ?? DefaultDashboardPassword);
+
+    /// <summary>Gets the dashboard password Tunnel Agent will use for local management requests.</summary>
+    public static string DashboardPassword =>
+        UserEnvironmentService.Get(DashboardPasswordEnvVarName) ?? DefaultDashboardPassword;
 
     /// <summary>Gets the loopback port this client was constructed with.</summary>
     public int Port { get; }
@@ -172,6 +185,26 @@ public sealed class ApiClient : IDisposable
     {
         ArgumentNullException.ThrowIfNull(request);
         using var response = await SendWithAuthRetryAsync(HttpMethod.Patch, "api/settings", request, ct)
+            .ConfigureAwait(false);
+        return await ReadJsonAsync<NineRouterSettings>(response, ct).ConfigureAwait(false);
+    }
+
+    /// <summary>Updates the dashboard-login setting or password via <c>PATCH /api/settings</c>.</summary>
+    /// <remarks>Passwords are only sent to the local 9Router process and are never logged.</remarks>
+    public async Task<NineRouterSettings> UpdateDashboardSecurityAsync(
+        bool? requireLogin = null,
+        string? currentPassword = null,
+        string? newPassword = null,
+        CancellationToken ct = default)
+    {
+        if (requireLogin is null && string.IsNullOrWhiteSpace(newPassword))
+            throw new ArgumentException("Specify a dashboard security change.");
+
+        using var response = await SendWithAuthRetryAsync(
+                HttpMethod.Patch,
+                "api/settings",
+                new UpdateDashboardSecurityRequest(requireLogin, currentPassword, newPassword),
+                ct)
             .ConfigureAwait(false);
         return await ReadJsonAsync<NineRouterSettings>(response, ct).ConfigureAwait(false);
     }
@@ -515,6 +548,15 @@ public sealed class ApiClient : IDisposable
         return await ReadJsonAsync<NineRouterCreatedApiKey>(response, ct).ConfigureAwait(false);
     }
 
+    /// <summary>Deletes a client API key via <c>DELETE /api/keys/{id}</c>.</summary>
+    public async Task DeleteKeyAsync(string id, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        using var response = await SendWithAuthRetryAsync(HttpMethod.Delete, KeyPath(id), body: null, ct)
+            .ConfigureAwait(false);
+        await EnsureSuccessAsync(response, ct).ConfigureAwait(false);
+    }
+
     /// <inheritdoc />
     public void Dispose()
     {
@@ -697,6 +739,9 @@ public sealed class ApiClient : IDisposable
     private static string ComboPath(string id) =>
         "api/combos/" + Uri.EscapeDataString(id);
 
+    private static string KeyPath(string id) =>
+        "api/keys/" + Uri.EscapeDataString(id);
+
     private static string UsagePath(string connectionId) =>
         "api/usage/" + Uri.EscapeDataString(connectionId);
 
@@ -744,6 +789,11 @@ public sealed class ApiClient : IDisposable
     private sealed record KeyListResponse(List<NineRouterApiKey>? Keys, string? Error);
 
     private sealed record CreateKeyRequest(string Name);
+
+    private sealed record UpdateDashboardSecurityRequest(
+        bool? RequireLogin,
+        string? CurrentPassword,
+        string? NewPassword);
 
     private sealed record LoginRequest(string Password);
 

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ApiModels.cs
@@ -87,6 +87,12 @@ public sealed record NineRouterProvider
 /// <summary>9Router settings used to configure model-combo strategies.</summary>
 public sealed record NineRouterSettings
 {
+    /// <summary>Gets whether dashboard access requires authentication.</summary>
+    public bool RequireLogin { get; init; }
+
+    /// <summary>Gets whether callers must provide a valid API key.</summary>
+    public bool RequireApiKey { get; init; }
+
     /// <summary>Gets per-provider routing overrides keyed by provider id.</summary>
     public Dictionary<string, NineRouterProviderStrategy> ProviderStrategies { get; init; } = [];
 
@@ -158,11 +164,14 @@ public sealed record NineRouterUpdateComboRequest
     public required List<string> Models { get; init; }
 }
 
-/// <summary>Body for <c>PATCH /api/settings</c> when replacing provider routing overrides.</summary>
+/// <summary>Body for <c>PATCH /api/settings</c>. Null properties are omitted.</summary>
 public sealed record NineRouterUpdateSettingsRequest
 {
-    /// <summary>Gets the complete per-provider routing-override map.</summary>
-    public required Dictionary<string, NineRouterProviderStrategy> ProviderStrategies { get; init; }
+    /// <summary>Gets the complete per-provider routing-override map, when changing it.</summary>
+    public Dictionary<string, NineRouterProviderStrategy>? ProviderStrategies { get; init; }
+
+    /// <summary>Gets whether callers must provide a valid API key.</summary>
+    public bool? RequireApiKey { get; init; }
 }
 
 /// <summary>Body for <c>PATCH /api/settings</c> when replacing combo strategies.</summary>

--- a/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterApiClientTests.cs
@@ -88,6 +88,47 @@ public sealed class NineRouterApiClientTests
     }
 
     [Fact]
+    public async Task UpdateSettingsAsync_UpdatesApiKeyRequirement()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "requireApiKey": true }""");
+        using var client = new ApiClient(Port, handler);
+
+        var settings = await client.UpdateSettingsAsync(new NineRouterUpdateSettingsRequest
+        {
+            RequireApiKey = true
+        });
+
+        Assert.True(settings.RequireApiKey);
+        Assert.Equal("PATCH", handler.Requests[0].Method);
+        Assert.Equal("/api/settings", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.True(body.RootElement.GetProperty("requireApiKey").GetBoolean());
+        Assert.False(body.RootElement.TryGetProperty("providerStrategies", out _));
+    }
+
+    [Fact]
+    public async Task UpdateDashboardSecurityAsync_UpdatesLoginAndPassword()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "requireLogin": true }""");
+        using var client = new ApiClient(Port, handler, dashboardPassword: "old-password");
+
+        var settings = await client.UpdateDashboardSecurityAsync(
+            requireLogin: true,
+            currentPassword: "old-password",
+            newPassword: "new-password");
+
+        Assert.True(settings.RequireLogin);
+        Assert.Equal("PATCH", handler.Requests[0].Method);
+        Assert.Equal("/api/settings", handler.Requests[0].Path);
+        using var body = JsonDocument.Parse(handler.Requests[0].Body!);
+        Assert.True(body.RootElement.GetProperty("requireLogin").GetBoolean());
+        Assert.Equal("old-password", body.RootElement.GetProperty("currentPassword").GetString());
+        Assert.Equal("new-password", body.RootElement.GetProperty("newPassword").GetString());
+    }
+
+    [Fact]
     public async Task CombosAsync_UsesManagementEndpoints()
     {
         using var handler = new FakeApiHandler();
@@ -362,6 +403,20 @@ public sealed class NineRouterApiClientTests
         Assert.Equal("sk-9r-new", created.Key);
         using var body = JsonDocument.Parse(handler.Requests[0].Body!);
         Assert.Equal("tunnel-agent", body.RootElement.GetProperty("name").GetString());
+    }
+
+    [Fact]
+    public async Task DeleteKeyAsync_DeletesEscapedKeyId()
+    {
+        using var handler = new FakeApiHandler();
+        handler.EnqueueJson(HttpStatusCode.OK, """{ "message": "Key deleted successfully" }""");
+        using var client = new ApiClient(Port, handler);
+
+        await client.DeleteKeyAsync("key/one");
+
+        Assert.Equal("DELETE", handler.Requests[0].Method);
+        Assert.Equal("/api/keys/key%2Fone", handler.Requests[0].Path);
+        Assert.Null(handler.Requests[0].Body);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- manage 9Router client API keys and defaults from Configuration
- configure dashboard login, password, and API-key requirements
- retain the dashboard password for local management requests

## Tests
- dotnet test TunnelAgent.Tests (9Router API and MainWindowViewModel filters)