### PR TITLE
fix: scroll sidebar nav when submenus overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Sidebar nav clipped when Quota and Fallback submenus are expanded** (`MainWindow.axaml`): the navigation list now lives in the sidebar's remaining-height row inside a `ScrollViewer`, so extra items scroll instead of pushing Status and the footer off-screen in a short window.
+
 ## [1.1.1] - 2026-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Sidebar nav clipped when Quota and Fallback submenus are expanded** (`MainWindow.axaml`): the navigation list now lives in the sidebar's remaining-height row inside a `ScrollViewer`, so extra items scroll instead of pushing Status and the footer off-screen in a short window.
+- **Sidebar overlay scrollbar sat on nav badges** (`MainWindow.axaml`, `Controls.axaml`): inset the nav scroller so the thumb sits in a gutter instead of against chevrons and counts.
 
 ## [1.1.1] - 2026-08-15
 

--- a/src/TunnelAgent.Avalonia/Themes/Controls.axaml
+++ b/src/TunnelAgent.Avalonia/Themes/Controls.axaml
@@ -354,6 +354,11 @@
         <Setter Property="TextElement.Foreground" Value="{DynamicResource AccentBrush}" />
     </Style>
 
+    <!-- Overlay thumb sits in the nav scroller padding, not on badges/chevrons. -->
+    <Style Selector="ScrollViewer.sidebar-nav /template/ ScrollBar">
+        <Setter Property="Margin" Value="0,4,2,4" />
+    </Style>
+
     <!-- Sidebar footer proxy status card (Quotio-style) -->
     <Style Selector="Button.proxy-card">
         <Setter Property="Background" Value="Transparent" />

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -134,7 +134,9 @@
                         </Grid>
 
                         <ScrollViewer Grid.Row="1"
-                                      Margin="8,0,8,0"
+                                      Classes="sidebar-nav"
+                                      Margin="8,0,4,0"
+                                      Padding="0,0,8,0"
                                       HorizontalScrollBarVisibility="Disabled"
                                       VerticalScrollBarVisibility="Auto">
                             <Panel x:Name="SidebarNav">

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -91,8 +91,7 @@
                         </Transitions>
                     </Border.Transitions>
                     <Grid RowDefinitions="Auto,*,Auto,Auto">
-                        <StackPanel Grid.Row="0" Margin="8,10,8,0" Spacing="2">
-                            <Grid Margin="0,0,0,16" ColumnDefinitions="*,Auto">
+                        <Grid Grid.Row="0" Margin="8,10,8,16" ColumnDefinitions="*,Auto">
                                 <Panel Grid.ColumnSpan="2"
                                        Opacity="{Binding SidebarContentOpacity}">
                                     <Panel.Transitions>
@@ -132,8 +131,12 @@
                                                                Foreground="{DynamicResource FgMutedBrush}" />
                                     </Panel>
                                 </Button>
-                            </Grid>
+                        </Grid>
 
+                        <ScrollViewer Grid.Row="1"
+                                      Margin="8,0,8,0"
+                                      HorizontalScrollBarVisibility="Disabled"
+                                      VerticalScrollBarVisibility="Auto">
                             <Panel x:Name="SidebarNav">
                             <Border x:Name="SidebarPill"
                                     Background="{DynamicResource AccentBrush}"
@@ -319,7 +322,7 @@
                             </Button>
                             </StackPanel>
                             </Panel>
-                        </StackPanel>
+                        </ScrollViewer>
 
                         <StackPanel Grid.Row="2" Margin="8,0,8,10" Spacing="6">
                             <Border Height="1" Margin="2,0,2,2" Background="{DynamicResource SideBorderBrush}" />


### PR DESCRIPTION
## Summary
- Put the sidebar navigation in the remaining-height row inside a `ScrollViewer`, so Quota and Fallback submenus no longer push Status and the footer off-screen in a short window.
- Keep the header, Status block, and footer pinned; extra nav items scroll instead of clipping.

## Test plan
- [ ] Resize the window toward the minimum height with both Quota and Fallback submenus expanded; Status and the footer stay visible.
- [ ] Confirm the nav list scrolls (mouse wheel / scrollbar) so Home through Configuration remain reachable.
- [ ] With the window tall enough that everything fits, no scrollbar should appear and layout should match before.
- [ ] Collapse/expand the sidebar and switch the selected section; the sliding pill still tracks the active item.

Made with [Cursor](https://cursor.com)