### PR TITLE
fix: kill 9Router process tree when Tunnel Agent crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **9Router left running after Tunnel Agent crashes** (`NineRouter/ProcessService`): the Node.js process tree is assigned to a Windows job with kill-on-close so a crash or Task Manager kill of Tunnel Agent also terminates 9Router, and a PID file is reaped on the next start if a leftover instance still holds the port.
+
 ## [1.1.1] - 2026-08-15
 
 ### Added

--- a/src/TunnelAgent.Infrastructure/Engine/EnginePidFile.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/EnginePidFile.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text.Json;
+
+namespace TunnelAgent.Infrastructure.Engine;
+
+/// <summary>
+/// Records a managed engine PID so a later Tunnel Agent process can reap a leftover
+/// instance after a crash that did not tear the child down.
+/// </summary>
+internal static class EnginePidFile
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = false };
+    private static readonly TimeSpan StartTimeTolerance = TimeSpan.FromSeconds(2);
+
+    /// <summary>On-disk record of a process started by Tunnel Agent.</summary>
+    internal sealed class Record
+    {
+        public int Pid { get; set; }
+        public DateTime StartTimeUtc { get; set; }
+        public string ServerEntryPath { get; set; } = "";
+    }
+
+    /// <summary>
+    /// PID file stored beside the extracted package: <c>{engineDir}/engine.pid</c>,
+    /// derived from <c>{engineDir}/app/custom-server.js</c> (or <c>server.js</c>).
+    /// </summary>
+    public static string PathForServerEntry(string serverEntryPath)
+    {
+        var appDir = Path.GetDirectoryName(serverEntryPath);
+        if (string.IsNullOrEmpty(appDir))
+            throw new ArgumentException("Server entry path must include a directory.", nameof(serverEntryPath));
+
+        var engineDir = Path.GetDirectoryName(appDir);
+        if (string.IsNullOrEmpty(engineDir))
+            throw new ArgumentException("Server entry path must be inside an engine directory.", nameof(serverEntryPath));
+
+        return Path.Combine(engineDir, "engine.pid");
+    }
+
+    /// <summary>Writes <paramref name="process"/> identity so a future start can reap it.</summary>
+    public static void Write(string path, Process process, string serverEntryPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(process);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serverEntryPath);
+
+        var record = new Record
+        {
+            Pid = process.Id,
+            StartTimeUtc = process.StartTime.ToUniversalTime(),
+            ServerEntryPath = Path.GetFullPath(serverEntryPath)
+        };
+
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        var json = JsonSerializer.Serialize(record, JsonOptions);
+        var tmpPath = path + ".tmp";
+        File.WriteAllText(tmpPath, json);
+        if (File.Exists(path))
+            File.Replace(tmpPath, path, null);
+        else
+            File.Move(tmpPath, path);
+    }
+
+    /// <summary>Deletes <paramref name="path"/> if it exists. Ignores I/O errors.</summary>
+    public static void Delete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // Best-effort: a stale file is reaped or ignored on the next start.
+        }
+    }
+
+    /// <summary>Reads a PID file, or <see langword="null"/> when missing or malformed.</summary>
+    public static Record? Read(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+
+            var record = JsonSerializer.Deserialize<Record>(File.ReadAllText(path), JsonOptions);
+            if (record is null || record.Pid <= 0 || string.IsNullOrWhiteSpace(record.ServerEntryPath))
+                return null;
+
+            return record;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Kills the recorded process tree when it is still the same engine instance.
+    /// Returns <see langword="true"/> when a live matching process was terminated.
+    /// </summary>
+    public static bool TryKillRecorded(string path, string serverEntryPath)
+    {
+        var record = Read(path);
+        if (record is null)
+        {
+            Delete(path);
+            return false;
+        }
+
+        if (!PathsEqual(record.ServerEntryPath, serverEntryPath))
+            return false;
+
+        var killed = false;
+        try
+        {
+            if (IsSameEngineProcess(record, serverEntryPath))
+            {
+                using var process = Process.GetProcessById(record.Pid);
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                    process.WaitForExit(2000);
+                    killed = true;
+                }
+            }
+        }
+        catch (ArgumentException)
+        {
+            // PID is not running.
+        }
+        catch (InvalidOperationException)
+        {
+            // Process exited between lookup and kill.
+        }
+        catch
+        {
+            // Access denied or the process cannot be signaled — leave the file for a retry.
+            return false;
+        }
+
+        Delete(path);
+        return killed;
+    }
+
+    internal static bool IsSameEngineProcess(Record record, string serverEntryPath)
+    {
+        if (!PathsEqual(record.ServerEntryPath, serverEntryPath))
+            return false;
+
+        Process process;
+        try
+        {
+            process = Process.GetProcessById(record.Pid);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (process.HasExited)
+                return false;
+
+            var startUtc = process.StartTime.ToUniversalTime();
+            var delta = (startUtc - record.StartTimeUtc).Duration();
+            return delta <= StartTimeTolerance;
+        }
+        catch
+        {
+            return false;
+        }
+        finally
+        {
+            process.Dispose();
+        }
+    }
+
+    private static bool PathsEqual(string left, string right)
+    {
+        try
+        {
+            left = Path.GetFullPath(left);
+            right = Path.GetFullPath(right);
+        }
+        catch
+        {
+            return false;
+        }
+
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(left, right, comparison);
+    }
+}

--- a/src/TunnelAgent.Infrastructure/Engine/KillOnCloseJob.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/KillOnCloseJob.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+
+namespace TunnelAgent.Infrastructure.Engine;
+
+/// <summary>
+/// Windows job object with <c>JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE</c>. Child processes
+/// assigned to the job are terminated when the last handle is closed — including when
+/// Tunnel Agent crashes or is killed, because the OS closes the handle on process exit.
+/// </summary>
+/// <remarks>
+/// Intentionally not a <see cref="SafeHandle"/>: a GC finalizer would close the handle and
+/// kill the engine while Tunnel Agent is still running. The owning <c>ProcessService</c>
+/// keeps this instance alive and disposes it only on an explicit stop.
+/// </remarks>
+internal sealed class KillOnCloseJob : IDisposable
+{
+    private IntPtr _handle;
+
+    private KillOnCloseJob(IntPtr handle) => _handle = handle;
+
+    /// <summary>
+    /// Creates an unnamed kill-on-close job on Windows. Returns <see langword="null"/> on
+    /// other platforms or if the job cannot be created.
+    /// </summary>
+    public static KillOnCloseJob? TryCreate()
+    {
+        if (!OperatingSystem.IsWindows())
+            return null;
+
+        return TryCreateWindows();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static KillOnCloseJob? TryCreateWindows()
+    {
+        var handle = NativeMethods.CreateJobObject(IntPtr.Zero, null);
+        if (handle == IntPtr.Zero)
+            return null;
+
+        var info = new NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            BasicLimitInformation = new NativeMethods.JOBOBJECT_BASIC_LIMIT_INFORMATION
+            {
+                LimitFlags = NativeMethods.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+            }
+        };
+
+        var size = Marshal.SizeOf<NativeMethods.JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+        if (!NativeMethods.SetInformationJobObject(
+                handle,
+                NativeMethods.JobObjectExtendedLimitInformation,
+                ref info,
+                size))
+        {
+            NativeMethods.CloseHandle(handle);
+            return null;
+        }
+
+        return new KillOnCloseJob(handle);
+    }
+
+    /// <summary>
+    /// Assigns <paramref name="process"/> to this job so it (and its children) die with the job.
+    /// Returns <see langword="false"/> when assignment fails (for example nested-job limits).
+    /// </summary>
+    public bool TryAssign(Process process)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        if (!OperatingSystem.IsWindows() || _handle == IntPtr.Zero)
+            return false;
+
+        return TryAssignWindows(process);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private bool TryAssignWindows(Process process)
+    {
+        try
+        {
+            return NativeMethods.AssignProcessToJobObject(_handle, process.Handle);
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_handle == IntPtr.Zero)
+            return;
+
+        if (OperatingSystem.IsWindows())
+            NativeMethods.CloseHandle(_handle);
+
+        _handle = IntPtr.Zero;
+        GC.SuppressFinalize(this);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static class NativeMethods
+    {
+        public const uint JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x2000;
+        public const int JobObjectExtendedLimitInformation = 9;
+
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        public static extern IntPtr CreateJobObject(IntPtr lpJobAttributes, string? lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetInformationJobObject(
+            IntPtr hJob,
+            int jobObjectInformationClass,
+            ref JOBOBJECT_EXTENDED_LIMIT_INFORMATION lpJobObjectInfo,
+            int cbJobObjectInfoLength);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool AssignProcessToJobObject(IntPtr hJob, IntPtr hProcess);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CloseHandle(IntPtr hObject);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+        {
+            public long PerProcessUserTimeLimit;
+            public long PerJobUserTimeLimit;
+            public uint LimitFlags;
+            public nuint MinimumWorkingSetSize;
+            public nuint MaximumWorkingSetSize;
+            public uint ActiveProcessLimit;
+            public nuint Affinity;
+            public uint PriorityClass;
+            public uint SchedulingClass;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct IO_COUNTERS
+        {
+            public ulong ReadOperationCount;
+            public ulong WriteOperationCount;
+            public ulong OtherOperationCount;
+            public ulong ReadTransferCount;
+            public ulong WriteTransferCount;
+            public ulong OtherTransferCount;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+        {
+            public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+            public IO_COUNTERS IoInfo;
+            public nuint ProcessMemoryLimit;
+            public nuint JobMemoryLimit;
+            public nuint PeakProcessMemoryUsed;
+            public nuint PeakJobMemoryUsed;
+        }
+    }
+}

--- a/src/TunnelAgent.Infrastructure/Engine/NineRouter/ProcessService.cs
+++ b/src/TunnelAgent.Infrastructure/Engine/NineRouter/ProcessService.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using TunnelAgent.Core.Engine;
+using TunnelAgent.Infrastructure.Engine;
 
 namespace TunnelAgent.Infrastructure.Engine.NineRouter;
 
@@ -38,9 +39,13 @@ public sealed class ProcessService
     public event EventHandler? StateChanged;
 
     private Process? _process;
+    private KillOnCloseJob? _job;
+    private string? _pidFilePath;
 
     /// <summary>
     /// Starts Node.js against the extracted standalone server on loopback.
+    /// Reaps a leftover instance recorded from a previous crash, then assigns the
+    /// new process to a Windows kill-on-close job so the tree dies with Tunnel Agent.
     /// Does not throw when the port is taken or the executable cannot be launched;
     /// those cases set <see cref="State"/> to <see cref="EngineState.Error"/>.
     /// </summary>
@@ -52,11 +57,11 @@ public sealed class ProcessService
     {
         Port = port;
         SetState(EngineState.Starting);
-
-        if (_process is not null)
+        StopProcess();
+        if (ReapLeftoverEngine(serverEntryPath))
         {
-            _process.Dispose();
-            _process = null;
+            for (var i = 0; i < 10 && IsPortInUse(port); i++)
+                await Task.Delay(100, ct);
         }
 
         // Pre-flight: fail fast with a clear message if the port is already taken.
@@ -97,6 +102,7 @@ public sealed class ProcessService
         try
         {
             _process.Start();
+            AttachLifetimeGuards(serverEntryPath);
         }
         catch (Exception ex)
         {
@@ -109,7 +115,17 @@ public sealed class ProcessService
 
         _process.BeginErrorReadLine();
 
-        var result = await WaitForHealthAsync(port, ct);
+        HealthResult result;
+        try
+        {
+            result = await WaitForHealthAsync(port, ct);
+        }
+        catch
+        {
+            StopProcess();
+            throw;
+        }
+
         if (result != HealthResult.Healthy)
         {
             if (result == HealthResult.ProcessExited)
@@ -170,6 +186,42 @@ public sealed class ProcessService
         return startInfo;
     }
 
+    private void AttachLifetimeGuards(string serverEntryPath)
+    {
+        if (_process is null)
+            return;
+
+        _job = KillOnCloseJob.TryCreate();
+        if (_job is not null && !_job.TryAssign(_process))
+        {
+            _job.Dispose();
+            _job = null;
+        }
+
+        try
+        {
+            _pidFilePath = EnginePidFile.PathForServerEntry(serverEntryPath);
+            EnginePidFile.Write(_pidFilePath, _process, serverEntryPath);
+        }
+        catch
+        {
+            _pidFilePath = null;
+        }
+    }
+
+    private static bool ReapLeftoverEngine(string serverEntryPath)
+    {
+        try
+        {
+            return EnginePidFile.TryKillRecorded(EnginePidFile.PathForServerEntry(serverEntryPath), serverEntryPath);
+        }
+        catch
+        {
+            // Starting still proceeds; a leftover will surface as port-in-use.
+            return false;
+        }
+    }
+
     private void StopProcess()
     {
         try
@@ -182,6 +234,13 @@ public sealed class ProcessService
         {
             _process?.Dispose();
             _process = null;
+            _job?.Dispose();
+            _job = null;
+            if (_pidFilePath is not null)
+            {
+                EnginePidFile.Delete(_pidFilePath);
+                _pidFilePath = null;
+            }
         }
     }
 

--- a/tests/TunnelAgent.Tests/EnginePidFileTests.cs
+++ b/tests/TunnelAgent.Tests/EnginePidFileTests.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using TunnelAgent.Infrastructure.Engine;
+
+namespace TunnelAgent.Tests;
+
+public sealed class EnginePidFileTests
+{
+    [Fact]
+    public void PathForServerEntry_UsesEngineDirectory()
+    {
+        using var temp = new TestTempDirectory();
+        var serverPath = Path.Combine(temp.Path, "app", "custom-server.js");
+
+        var pidPath = EnginePidFile.PathForServerEntry(serverPath);
+
+        Assert.Equal(Path.Combine(temp.Path, "engine.pid"), pidPath);
+    }
+
+    [Fact]
+    public void PathForServerEntry_MissingDirectory_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => EnginePidFile.PathForServerEntry("custom-server.js"));
+    }
+
+    [Fact]
+    public void Read_MissingOrMalformed_ReturnsNull()
+    {
+        using var temp = new TestTempDirectory();
+        var path = temp.File("engine.pid");
+
+        Assert.Null(EnginePidFile.Read(path));
+
+        File.WriteAllText(path, "{not-json");
+        Assert.Null(EnginePidFile.Read(path));
+
+        File.WriteAllText(path, """{"pid":0,"startTimeUtc":"2026-01-01T00:00:00Z","serverEntryPath":"x"}""");
+        Assert.Null(EnginePidFile.Read(path));
+    }
+
+    [Fact]
+    public void TryKillRecorded_MatchingProcess_KillsAndDeletesFile()
+    {
+        using var temp = new TestTempDirectory();
+        var serverPath = Path.Combine(temp.Path, "app", "custom-server.js");
+        Directory.CreateDirectory(Path.GetDirectoryName(serverPath)!);
+        File.WriteAllText(serverPath, "// stub");
+        var pidPath = EnginePidFile.PathForServerEntry(serverPath);
+
+        using var leftover = StartHangProcess();
+        try
+        {
+            EnginePidFile.Write(pidPath, leftover, serverPath);
+            Assert.True(File.Exists(pidPath));
+
+            Assert.True(EnginePidFile.TryKillRecorded(pidPath, serverPath));
+
+            leftover.WaitForExit(2000);
+            leftover.Refresh();
+            Assert.True(leftover.HasExited);
+            Assert.False(File.Exists(pidPath));
+        }
+        finally
+        {
+            TryKill(leftover);
+        }
+    }
+
+    [Fact]
+    public void TryKillRecorded_DifferentServerEntry_LeavesProcessAndFile()
+    {
+        using var temp = new TestTempDirectory();
+        var serverPath = Path.Combine(temp.Path, "app", "custom-server.js");
+        var otherPath = Path.Combine(temp.Path, "app", "server.js");
+        Directory.CreateDirectory(Path.GetDirectoryName(serverPath)!);
+        File.WriteAllText(serverPath, "// stub");
+        var pidPath = EnginePidFile.PathForServerEntry(serverPath);
+
+        using var leftover = StartHangProcess();
+        try
+        {
+            EnginePidFile.Write(pidPath, leftover, serverPath);
+
+            Assert.False(EnginePidFile.TryKillRecorded(pidPath, otherPath));
+            leftover.Refresh();
+            Assert.False(leftover.HasExited);
+            Assert.True(File.Exists(pidPath));
+        }
+        finally
+        {
+            TryKill(leftover);
+        }
+    }
+
+    [Fact]
+    public void TryKillRecorded_StalePid_DeletesFileWithoutThrowing()
+    {
+        using var temp = new TestTempDirectory();
+        var serverPath = Path.Combine(temp.Path, "app", "custom-server.js");
+        Directory.CreateDirectory(Path.GetDirectoryName(serverPath)!);
+        var pidPath = EnginePidFile.PathForServerEntry(serverPath);
+        var record = new EnginePidFile.Record
+        {
+            Pid = 2147483647,
+            StartTimeUtc = new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            ServerEntryPath = Path.GetFullPath(serverPath)
+        };
+        File.WriteAllText(pidPath, System.Text.Json.JsonSerializer.Serialize(record));
+
+        Assert.False(EnginePidFile.TryKillRecorded(pidPath, serverPath));
+        Assert.False(File.Exists(pidPath));
+    }
+
+    internal static Process StartHangProcess()
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? new ProcessStartInfo("ping")
+            {
+                Arguments = "-n 60 127.0.0.1",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }
+            : new ProcessStartInfo("sleep")
+            {
+                ArgumentList = { "60" },
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+        var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        return process!;
+    }
+
+    internal static void TryKill(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Test cleanup.
+        }
+    }
+}

--- a/tests/TunnelAgent.Tests/KillOnCloseJobTests.cs
+++ b/tests/TunnelAgent.Tests/KillOnCloseJobTests.cs
@@ -1,0 +1,47 @@
+using TunnelAgent.Infrastructure.Engine;
+
+namespace TunnelAgent.Tests;
+
+public sealed class KillOnCloseJobTests
+{
+    [Fact]
+    public void TryCreate_WindowsReturnsJob_UnixReturnsNull()
+    {
+        var job = KillOnCloseJob.TryCreate();
+        try
+        {
+            if (OperatingSystem.IsWindows())
+                Assert.NotNull(job);
+            else
+                Assert.Null(job);
+        }
+        finally
+        {
+            job?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void Dispose_OnWindows_KillsAssignedProcess()
+    {
+        if (!OperatingSystem.IsWindows())
+            return;
+
+        using var process = EnginePidFileTests.StartHangProcess();
+        try
+        {
+            using var job = KillOnCloseJob.TryCreate();
+            Assert.NotNull(job);
+            Assert.True(job!.TryAssign(process));
+            job.Dispose();
+
+            Assert.True(process.WaitForExit(3000));
+            process.Refresh();
+            Assert.True(process.HasExited);
+        }
+        finally
+        {
+            EnginePidFileTests.TryKill(process);
+        }
+    }
+}

--- a/tests/TunnelAgent.Tests/NineRouterProcessServiceTests.cs
+++ b/tests/TunnelAgent.Tests/NineRouterProcessServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Sockets;
 using TunnelAgent.Core.Engine;
+using TunnelAgent.Infrastructure.Engine;
 using TunnelAgent.Infrastructure.Engine.NineRouter;
 
 namespace TunnelAgent.Tests;
@@ -81,6 +82,36 @@ public sealed class NineRouterProcessServiceTests
         Assert.True(
             startInfo.Environment.ContainsKey("PATH") || startInfo.Environment.ContainsKey("Path"),
             "Current process environment should be inherited.");
+    }
+
+    [Fact]
+    public async Task StartAsync_ReapsRecordedLeftoverProcess()
+    {
+        using var temp = new TestTempDirectory();
+        var serverPath = CreateServerEntry(temp);
+        var pidPath = EnginePidFile.PathForServerEntry(serverPath);
+        var port = GetFreePort();
+        var missingNode = temp.File(OperatingSystem.IsWindows() ? "nonexistent-node.exe" : "nonexistent-node");
+
+        using var leftover = EnginePidFileTests.StartHangProcess();
+        try
+        {
+            EnginePidFile.Write(pidPath, leftover, serverPath);
+            var service = new ProcessService();
+
+            await service.StartAsync(missingNode, serverPath, port);
+
+            leftover.WaitForExit(2000);
+            leftover.Refresh();
+            Assert.True(leftover.HasExited);
+            Assert.False(File.Exists(pidPath));
+            Assert.Equal(EngineState.Error, service.State);
+            Assert.Equal(EngineErrorKind.LaunchFailed, service.LastErrorKind);
+        }
+        finally
+        {
+            EnginePidFileTests.TryKill(leftover);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Assign the 9Router Node.js process tree to a Windows job with kill-on-close so a Tunnel Agent crash or Task Manager kill also terminates the engine.
- Record a PID file and reap it on the next start if a leftover instance still holds the port.

## Test plan
- [ ] Start 9Router, kill Tunnel Agent from Task Manager (End process, not End process tree), and confirm the Node.js 9Router process exits.
- [ ] After a leftover from an older build, start 9Router again and confirm the recorded PID is reaped and the port is free.
- [ ] Quit normally from the tray and confirm 9Router still stops cleanly.

Made with [Cursor](https://cursor.com)