### PR TITLE
fix: show collapsed sidebar submenus in a flyout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Collapsed sidebar hid Quota and Fallback children** (`MainWindow.axaml`, `MainWindow.axaml.cs`, `Controls.axaml`): collapsing the rail left empty selected submenu pills because child labels were hidden in-place. Those groups now open a flyout beside the icon, the parent keeps the sliding pill and hover while a child is active or the flyout is open, and first/last flyout hover fills the rounded corners.
+
 ## [1.1.1] - 2026-08-15
 
 ### Added

--- a/src/TunnelAgent.Avalonia/Themes/Controls.axaml
+++ b/src/TunnelAgent.Avalonia/Themes/Controls.axaml
@@ -324,6 +324,13 @@
     <Style Selector="Button.side:pointerover /template/ ContentPresenter">
         <Setter Property="Background" Value="#0F000000" />
     </Style>
+    <!-- Keep the parent hover while the pointer is on its collapsed flyout. -->
+    <Style Selector="Button.side.flyout-open /template/ ContentPresenter">
+        <Setter Property="Background" Value="#0F000000" />
+    </Style>
+    <Style Selector="Button.side.flyout-open.selected /template/ ContentPresenter">
+        <Setter Property="Background" Value="Transparent" />
+    </Style>
     <!-- Selected background is provided by the sliding pill behind the buttons
          (see MainWindow SidebarPill), so the item itself stays transparent. -->
     <Style Selector="Button.side.selected /template/ ContentPresenter">

--- a/src/TunnelAgent.Avalonia/Themes/Controls.axaml
+++ b/src/TunnelAgent.Avalonia/Themes/Controls.axaml
@@ -719,6 +719,35 @@
         <Setter Property="Cursor" Value="Arrow" />
     </Style>
 
+    <!-- Compact menu shown from collapsed sidebar items with children -->
+    <Style Selector="MenuFlyoutPresenter.sidebar-flyout">
+        <Setter Property="Background" Value="{DynamicResource SideBgBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CardBorderBrush}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="MinWidth" Value="188" />
+        <Setter Property="ClipToBounds" Value="True" />
+    </Style>
+    <!-- Fluent's presenter template ignores Padding and uses FlyoutBorderThemePadding /
+         MenuFlyoutScrollerMargin instead, which left a gap around first/last hover. -->
+    <Style Selector="MenuFlyoutPresenter.sidebar-flyout /template/ Border#LayoutRoot">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="ClipToBounds" Value="True" />
+    </Style>
+    <Style Selector="MenuFlyoutPresenter.sidebar-flyout /template/ ItemsPresenter#PART_ItemsPresenter">
+        <Setter Property="Margin" Value="0" />
+    </Style>
+    <Style Selector="MenuFlyoutPresenter.sidebar-flyout MenuItem:nth-child(1)">
+        <Setter Property="CornerRadius" Value="7,7,0,0" />
+    </Style>
+    <Style Selector="MenuFlyoutPresenter.sidebar-flyout MenuItem:nth-last-child(1)">
+        <Setter Property="CornerRadius" Value="0,0,7,7" />
+    </Style>
+    <Style Selector="MenuFlyoutPresenter.sidebar-flyout MenuItem:nth-child(1):nth-last-child(1)">
+        <Setter Property="CornerRadius" Value="7" />
+    </Style>
+
     <!-- Borderless expand/collapse chevron (no checked highlight) -->
     <Style Selector="ToggleButton.chevron">
         <Setter Property="Background" Value="Transparent" />

--- a/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/src/TunnelAgent.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -171,11 +171,20 @@ SelectedSection is SectionKey.Logs;
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsQuotaLimitsActive))]
     [NotifyPropertyChangedFor(nameof(IsQuotaUsageActive))]
+    [NotifyPropertyChangedFor(nameof(IsQuotaNavActive))]
+    [NotifyPropertyChangedFor(nameof(IsFallbackNavActive))]
     private SectionKey _selectedSection = SectionKey.Home;
     [ObservableProperty] private HomeDashboardTab _homeDashboardTab = HomeDashboardTab.LocalProxy;
-    [ObservableProperty] private bool _isSidebarCollapsed;
-    [ObservableProperty] private bool _isQuotaSubmenuExpanded;
-    [ObservableProperty] private bool _isFallbackSubmenuExpanded;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsQuotaSubmenuVisible))]
+    [NotifyPropertyChangedFor(nameof(IsFallbackSubmenuVisible))]
+    private bool _isSidebarCollapsed;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsQuotaSubmenuVisible))]
+    private bool _isQuotaSubmenuExpanded;
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFallbackSubmenuVisible))]
+    private bool _isFallbackSubmenuExpanded;
     [ObservableProperty] private bool _isDark;
     [ObservableProperty] private string _focusedConfigEngineId = EngineCatalog.CliProxyApi.Id;
     [ObservableProperty] private string _providersEngineId = EngineCatalog.CliProxyApi.Id;
@@ -585,6 +594,10 @@ SelectedSection is SectionKey.Logs;
     public bool IsQuotaLimitsSelected => !IsQuotaUsageSelected;
     public bool IsQuotaLimitsActive => SelectedSection == SectionKey.Quota && IsQuotaLimitsSelected;
     public bool IsQuotaUsageActive => SelectedSection == SectionKey.Quota && IsQuotaUsageSelected;
+    public bool IsQuotaNavActive => SelectedSection == SectionKey.Quota;
+    public bool IsFallbackNavActive => SelectedSection is SectionKey.Fallback or SectionKey.NineRouterCombos;
+    public bool IsQuotaSubmenuVisible => IsQuotaSubmenuExpanded && !IsSidebarCollapsed;
+    public bool IsFallbackSubmenuVisible => IsFallbackSubmenuExpanded && !IsSidebarCollapsed;
     public bool HasNineRouterUsageConnections => NineRouterConnections.Count > 0;
     public bool ShowNineRouterUsageEmptyState => IsNineRouterEngineRunning && !HasNineRouterUsageConnections;
 

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -196,6 +196,7 @@
 
                             <StackPanel Spacing="2">
                                 <Button Classes="side" IsVisible="{Binding !IsSidebarCollapsed}"
+                                        Classes.selected="{Binding IsQuotaNavActive}"
                                         Command="{Binding ToggleQuotaSubmenuCommand}">
                                     <Grid ColumnDefinitions="20,*,Auto">
                                         <lucide:PackIconLucide Grid.Column="0" Kind="ChartBar" Width="15" Height="15"
@@ -224,7 +225,8 @@
                                         Classes.selected="{Binding IsQuotaNavActive}"
                                         ToolTip.Tip="{l:Loc Sidebar_Quota}">
                                     <Button.Flyout>
-                                        <MenuFlyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="sidebar-flyout">
+                                        <MenuFlyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="sidebar-flyout"
+                                                    Opened="OnSidebarNavFlyoutOpened" Closed="OnSidebarNavFlyoutClosed">
                                             <MenuItem Header="{l:Loc Sidebar_Quota}"
                                                       Command="{Binding SelectQuotaLimitsCommand}"
                                                       IsChecked="{Binding IsQuotaLimitsActive, Mode=OneWay}" />
@@ -242,6 +244,7 @@
 
                             <StackPanel Spacing="2">
                                 <Button Classes="side" IsVisible="{Binding !IsSidebarCollapsed}"
+                                        Classes.selected="{Binding IsFallbackNavActive}"
                                         Command="{Binding ToggleFallbackSubmenuCommand}">
                                     <Grid ColumnDefinitions="20,*,Auto">
                                         <lucide:PackIconLucide Grid.Column="0" Kind="GitFork" Width="15" Height="15"
@@ -270,7 +273,8 @@
                                         Classes.selected="{Binding IsFallbackNavActive}"
                                         ToolTip.Tip="{l:Loc Sidebar_Fallback}">
                                     <Button.Flyout>
-                                        <MenuFlyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="sidebar-flyout">
+                                        <MenuFlyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="sidebar-flyout"
+                                                    Opened="OnSidebarNavFlyoutOpened" Closed="OnSidebarNavFlyoutClosed">
                                             <MenuItem Header="{l:Loc Sidebar_FallbackCliProxy}"
                                                       Command="{Binding SelectFallbackCommand}"
                                                       IsChecked="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Fallback, Mode=OneWay}" />

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -195,13 +195,14 @@
                             </Button>
 
                             <StackPanel Spacing="2">
-                                <Button Classes="side" Command="{Binding ToggleQuotaSubmenuCommand}">
+                                <Button Classes="side" IsVisible="{Binding !IsSidebarCollapsed}"
+                                        Command="{Binding ToggleQuotaSubmenuCommand}">
                                     <Grid ColumnDefinitions="20,*,Auto">
                                         <lucide:PackIconLucide Grid.Column="0" Kind="ChartBar" Width="15" Height="15"
                                                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="1" Text="{l:Loc Sidebar_Quota}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
-                                                   Opacity="{Binding SidebarContentOpacity}" IsVisible="{Binding !IsSidebarCollapsed}" />
-                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center" IsVisible="{Binding !IsSidebarCollapsed}">
+                                                   Opacity="{Binding SidebarContentOpacity}" />
+                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center">
                                             <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
                                                                     IsVisible="{Binding IsQuotaSubmenuExpanded, Converter={StaticResource InvertBool}}" />
                                             <lucide:PackIconLucide Kind="ChevronDown" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
@@ -209,28 +210,45 @@
                                         </Panel>
                                     </Grid>
                                 </Button>
-                                <StackPanel Spacing="2" Margin="18,0,0,0" IsVisible="{Binding IsQuotaSubmenuExpanded}">
+                                <StackPanel Spacing="2" Margin="18,0,0,0" IsVisible="{Binding IsQuotaSubmenuVisible}">
                                     <Button Classes="side side-sub" Classes.selected="{Binding IsQuotaLimitsActive}"
                                             Command="{Binding SelectQuotaLimitsCommand}">
-                                        <TextBlock Text="{l:Loc Sidebar_Quota}" FontSize="11" Margin="0"
-                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                        <TextBlock Text="{l:Loc Sidebar_Quota}" FontSize="11" Margin="0" />
                                     </Button>
                                     <Button Classes="side side-sub" Classes.selected="{Binding IsQuotaUsageActive}"
                                             Command="{Binding SelectQuotaUsageCommand}">
-                                        <TextBlock Text="{l:Loc Sidebar_NineRouterUsage}" FontSize="11" Margin="0"
-                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                        <TextBlock Text="{l:Loc Sidebar_NineRouterUsage}" FontSize="11" Margin="0" />
                                     </Button>
                                 </StackPanel>
+                                <Button Classes="side" IsVisible="{Binding IsSidebarCollapsed}"
+                                        Classes.selected="{Binding IsQuotaNavActive}"
+                                        ToolTip.Tip="{l:Loc Sidebar_Quota}">
+                                    <Button.Flyout>
+                                        <MenuFlyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="sidebar-flyout">
+                                            <MenuItem Header="{l:Loc Sidebar_Quota}"
+                                                      Command="{Binding SelectQuotaLimitsCommand}"
+                                                      IsChecked="{Binding IsQuotaLimitsActive, Mode=OneWay}" />
+                                            <MenuItem Header="{l:Loc Sidebar_NineRouterUsage}"
+                                                      Command="{Binding SelectQuotaUsageCommand}"
+                                                      IsChecked="{Binding IsQuotaUsageActive, Mode=OneWay}" />
+                                        </MenuFlyout>
+                                    </Button.Flyout>
+                                    <Grid ColumnDefinitions="20,*">
+                                        <lucide:PackIconLucide Grid.Column="0" Kind="ChartBar" Width="15" Height="15"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                    </Grid>
+                                </Button>
                             </StackPanel>
 
                             <StackPanel Spacing="2">
-                                <Button Classes="side" Command="{Binding ToggleFallbackSubmenuCommand}">
+                                <Button Classes="side" IsVisible="{Binding !IsSidebarCollapsed}"
+                                        Command="{Binding ToggleFallbackSubmenuCommand}">
                                     <Grid ColumnDefinitions="20,*,Auto">
                                         <lucide:PackIconLucide Grid.Column="0" Kind="GitFork" Width="15" Height="15"
                                                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="1" Text="{l:Loc Sidebar_Fallback}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
-                                                   Opacity="{Binding SidebarContentOpacity}" IsVisible="{Binding !IsSidebarCollapsed}" />
-                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center" IsVisible="{Binding !IsSidebarCollapsed}">
+                                                   Opacity="{Binding SidebarContentOpacity}" />
+                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center">
                                             <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
                                                                     IsVisible="{Binding IsFallbackSubmenuExpanded, Converter={StaticResource InvertBool}}" />
                                             <lucide:PackIconLucide Kind="ChevronDown" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
@@ -238,18 +256,34 @@
                                         </Panel>
                                     </Grid>
                                 </Button>
-                                <StackPanel Spacing="2" Margin="18,0,0,0" IsVisible="{Binding IsFallbackSubmenuExpanded}">
+                                <StackPanel Spacing="2" Margin="18,0,0,0" IsVisible="{Binding IsFallbackSubmenuVisible}">
                                     <Button Classes="side side-sub" Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Fallback}"
                                             Command="{Binding SelectFallbackCommand}">
-                                        <TextBlock Text="{l:Loc Sidebar_FallbackCliProxy}" FontSize="11" Margin="0"
-                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                        <TextBlock Text="{l:Loc Sidebar_FallbackCliProxy}" FontSize="11" Margin="0" />
                                     </Button>
                                     <Button Classes="side side-sub" Classes.selected="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=NineRouterCombos}"
                                             Command="{Binding SelectNineRouterCombosCommand}">
-                                        <TextBlock Text="{l:Loc Sidebar_NineRouterCombos}" FontSize="11" Margin="0"
-                                                   IsVisible="{Binding !IsSidebarCollapsed}" />
+                                        <TextBlock Text="{l:Loc Sidebar_NineRouterCombos}" FontSize="11" Margin="0" />
                                     </Button>
                                 </StackPanel>
+                                <Button Classes="side" IsVisible="{Binding IsSidebarCollapsed}"
+                                        Classes.selected="{Binding IsFallbackNavActive}"
+                                        ToolTip.Tip="{l:Loc Sidebar_Fallback}">
+                                    <Button.Flyout>
+                                        <MenuFlyout Placement="RightEdgeAlignedTop" FlyoutPresenterClasses="sidebar-flyout">
+                                            <MenuItem Header="{l:Loc Sidebar_FallbackCliProxy}"
+                                                      Command="{Binding SelectFallbackCommand}"
+                                                      IsChecked="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=Fallback, Mode=OneWay}" />
+                                            <MenuItem Header="{l:Loc Sidebar_NineRouterCombos}"
+                                                      Command="{Binding SelectNineRouterCombosCommand}"
+                                                      IsChecked="{Binding SelectedSection, Converter={StaticResource SectionEq}, ConverterParameter=NineRouterCombos, Mode=OneWay}" />
+                                        </MenuFlyout>
+                                    </Button.Flyout>
+                                    <Grid ColumnDefinitions="20,*">
+                                        <lucide:PackIconLucide Grid.Column="0" Kind="GitFork" Width="15" Height="15"
+                                                               HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                    </Grid>
+                                </Button>
                             </StackPanel>
 
                             <Button Classes="side"

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.Interactivity;
@@ -62,6 +63,9 @@ public partial class MainWindow : Window
             return;
         }
 
+        var origin = selected.TranslatePoint(new Point(0, 0), SidebarNav);
+        if (origin is null) return;
+
         // A pill returning from a selected submenu must snap in, not animate
         // from the last top-level item.
         var wasVisible = SidebarPill.IsVisible;
@@ -71,20 +75,32 @@ public partial class MainWindow : Window
 
         SidebarPill.Width = bounds.Width;
         SidebarPill.Height = bounds.Height;
-        translate.X = bounds.X;
+        translate.X = origin.Value.X;
 
         if (animate && wasVisible)
         {
-            translate.Y = bounds.Y;
+            translate.Y = origin.Value.Y;
         }
         else
         {
             // Place instantly by suspending the Y transition for this update.
             var transitions = translate.Transitions;
             translate.Transitions = null;
-            translate.Y = bounds.Y;
+            translate.Y = origin.Value.Y;
             translate.Transitions = transitions;
         }
+    }
+
+    private static void OnSidebarNavFlyoutOpened(object? sender, EventArgs e)
+    {
+        if (sender is FlyoutBase { Target: Control target })
+            target.Classes.Add("flyout-open");
+    }
+
+    private static void OnSidebarNavFlyoutClosed(object? sender, EventArgs e)
+    {
+        if (sender is FlyoutBase { Target: Control target })
+            target.Classes.Remove("flyout-open");
     }
 
     private void OnOpened(object? sender, EventArgs e)

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml.cs
@@ -10,6 +10,7 @@ using Avalonia.Input;
 using Avalonia.Threading;
 using Avalonia.Interactivity;
 using Avalonia.Styling;
+using Avalonia.VisualTree;
 using TunnelAgent.Infrastructure.Engine.CliProxy;
 using TunnelAgent.ViewModels;
 
@@ -50,9 +51,11 @@ public partial class MainWindow : Window
     {
         if (SidebarPill.RenderTransform is not Avalonia.Media.TranslateTransform translate) return;
 
-        var selected = SidebarNavItems.Children
+        var selected = SidebarNavItems.GetVisualDescendants()
             .OfType<Button>()
-            .FirstOrDefault(b => b.Classes.Contains("selected"));
+            .FirstOrDefault(b => b.IsVisible
+                                 && b.Classes.Contains("selected")
+                                 && !b.Classes.Contains("side-sub"));
         if (selected is null)
         {
             SidebarPill.IsVisible = false;
@@ -129,6 +132,10 @@ public partial class MainWindow : Window
         {
             UpdateSectionContent(vm);
             Dispatcher.UIThread.Post(() => MovePill(animate: true), DispatcherPriority.Render);
+        }
+        else if (args.PropertyName == nameof(MainWindowViewModel.IsSidebarCollapsed))
+        {
+            Dispatcher.UIThread.Post(() => MovePill(animate: false), DispatcherPriority.Render);
         }
         else if (args.PropertyName == nameof(MainWindowViewModel.ShowApiKeysDialog) && vm.ShowApiKeysDialog)
             Dispatcher.UIThread.Post(() => EnsureApiKeysOverlay(vm).FocusOverlay(), DispatcherPriority.Input);

--- a/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
+++ b/tests/TunnelAgent.Tests/MainWindowViewModelTests.cs
@@ -132,6 +132,29 @@ public sealed class MainWindowViewModelTests
     }
 
     [Fact]
+    public void CollapsedSidebar_HidesInlineSubmenusAndKeepsParentActive()
+    {
+        var vm = new MainWindowViewModel();
+
+        vm.SelectFallbackCommand.Execute(null);
+        Assert.True(vm.IsFallbackSubmenuVisible);
+        Assert.True(vm.IsFallbackNavActive);
+
+        vm.ToggleSidebarCommand.Execute(null);
+
+        Assert.True(vm.IsSidebarCollapsed);
+        Assert.True(vm.IsFallbackSubmenuExpanded);
+        Assert.False(vm.IsFallbackSubmenuVisible);
+        Assert.True(vm.IsFallbackNavActive);
+        Assert.False(vm.IsQuotaSubmenuVisible);
+
+        vm.SelectQuotaLimitsCommand.Execute(null);
+        Assert.True(vm.IsQuotaNavActive);
+        Assert.False(vm.IsFallbackNavActive);
+        Assert.False(vm.IsQuotaSubmenuVisible);
+    }
+
+    [Fact]
     public async Task QuotaSubmenu_TogglesAndSelectsBothViews()
     {
         var vm = new MainWindowViewModel();


### PR DESCRIPTION
## Summary
- Collapsed Quota/Fallback items hid their labels and left empty selected pills in the rail.
- Those groups now open a flyout beside the icon, and the parent stays marked while a child page is active.

## Test plan
- Collapse the sidebar with Quota or Fallback expanded: no empty gaps under the icons.
- Click the Quota and Fallback icons: the flyout lists both destinations and navigates correctly.
- Hover the first and last flyout items: the highlight fills the rounded corners.
- Expand the sidebar again: inline submenus still expand and select as before.