### PR TITLE
fix: keep icon buttons transparent on press

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **Icon buttons flashed a gray fill on click** (`Controls.axaml`): Fluent's pressed state still painted a background on `icon` / `icon-btn` controls. Press now stays transparent like the theme toggle, while scale feedback and the current pagination highlight are unchanged.
+
 ## [1.1.2] - 2026-08-17
 
 ### Fixed

--- a/src/TunnelAgent.Avalonia/Themes/Controls.axaml
+++ b/src/TunnelAgent.Avalonia/Themes/Controls.axaml
@@ -187,8 +187,11 @@
             </Transitions>
         </Setter>
     </Style>
-    <!-- Override Fluent's default hover fill while retaining the scale feedback. -->
+    <!-- Override Fluent's default hover/press fill while retaining the scale feedback. -->
     <Style Selector="Button.icon:pointerover /template/ ContentPresenter, Button.icon-btn:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="Transparent" />
+    </Style>
+    <Style Selector="Button.icon:pressed /template/ ContentPresenter, Button.icon-btn:pressed /template/ ContentPresenter">
         <Setter Property="Background" Value="Transparent" />
     </Style>
     <Style Selector="Button.icon:pointerover, Button.icon-btn:pointerover">
@@ -211,9 +214,6 @@
         <Setter Property="Padding" Value="0" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
-    </Style>
-    <Style Selector="Button.icon:pressed /template/ ContentPresenter">
-        <Setter Property="Background" Value="#26000000" />
     </Style>
 
     <Style Selector="Button.engine-action">
@@ -458,9 +458,6 @@
     </Style>
     <Style Selector="Button:pressed > Grid.theme-icon">
         <Setter Property="RenderTransform" Value="rotate(180deg) scale(0.85)" />
-    </Style>
-    <Style Selector="Button.theme-toggle:pressed /template/ ContentPresenter">
-        <Setter Property="Background" Value="Transparent" />
     </Style>
 
     <!-- Status indicator -->
@@ -819,9 +816,6 @@
         <Setter Property="Foreground" Value="{DynamicResource FgBrush}" />
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
-    </Style>
-    <Style Selector="Button.icon-btn:pressed /template/ ContentPresenter">
-        <Setter Property="Background" Value="#22000000" />
     </Style>
     <Style Selector="Button.icon-btn.engine-action:pressed /template/ ContentPresenter">
         <Setter Property="Background" Value="Transparent" />


### PR DESCRIPTION
## Summary
- Stop Fluent from painting a gray fill when `icon` / `icon-btn` buttons are pressed.
- Reuse the same transparent press override that already landed on the theme toggle.

## Test plan
- [ ] Click trash, copy, pagination, and other `icon-btn` controls: no background flash, scale feedback still plays.
- [ ] Toggle theme from the sidebar: still transparent on press, icon still spins.
- [ ] Current pagination page keeps its accent background while pressed.