### PR TITLE
Make sidebar chevrons white with rotate transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- **Sidebar submenu chevrons** (`MainWindow.axaml`, `Controls.axaml`, `FallbackView.axaml`): Quota and Fallback arrows now use the primary foreground color and rotate 90° with the same 0.18s CubicEaseOut transition as virtual-model expanders, instead of swapping muted right/down icons.
+
 ## [1.1.2] - 2026-08-17
 
 ### Fixed

--- a/src/TunnelAgent.Avalonia/Themes/Controls.axaml
+++ b/src/TunnelAgent.Avalonia/Themes/Controls.axaml
@@ -783,6 +783,20 @@
         <Setter Property="RenderTransform" Value="rotate(90deg)" />
     </Style>
 
+    <!-- Sidebar submenu chevron: same 90° rotate as virtual-model expanders -->
+    <Style Selector="Panel.sidebar-chevron">
+        <Setter Property="RenderTransformOrigin" Value="50%,50%" />
+        <Setter Property="RenderTransform" Value="rotate(0deg)" />
+        <Setter Property="Transitions">
+            <Transitions>
+                <TransformOperationsTransition Property="RenderTransform" Duration="0:0:0.18" Easing="CubicEaseOut" />
+            </Transitions>
+        </Setter>
+    </Style>
+    <Style Selector="Panel.sidebar-chevron.expanded">
+        <Setter Property="RenderTransform" Value="rotate(90deg)" />
+    </Style>
+
     <!-- Animated collapsible region (height + fade) -->
     <Style Selector="Border.collapsible">
         <Setter Property="ClipToBounds" Value="True" />

--- a/src/TunnelAgent.Avalonia/Views/FallbackView.axaml
+++ b/src/TunnelAgent.Avalonia/Views/FallbackView.axaml
@@ -120,7 +120,7 @@
                                               IsChecked="{Binding IsExpanded, Mode=TwoWay}">
                                     <lucide:PackIconLucide Kind="ChevronRight" Width="14" Height="14"
                                                            HorizontalAlignment="Center" VerticalAlignment="Center"
-                                                           Foreground="{DynamicResource FgMutedBrush}" />
+                                                           Foreground="{DynamicResource FgBrush}" />
                                 </ToggleButton>
 
                                 <StackPanel Grid.Column="1" VerticalAlignment="Center" Spacing="3">

--- a/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
+++ b/src/TunnelAgent.Avalonia/Views/MainWindow.axaml
@@ -208,11 +208,11 @@
                                                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="1" Text="{l:Loc Sidebar_Quota}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
                                                    Opacity="{Binding SidebarContentOpacity}" />
-                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center">
-                                            <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
-                                                                    IsVisible="{Binding IsQuotaSubmenuExpanded, Converter={StaticResource InvertBool}}" />
-                                            <lucide:PackIconLucide Kind="ChevronDown" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
-                                                                    IsVisible="{Binding IsQuotaSubmenuExpanded}" />
+                                        <Panel Grid.Column="2" Width="16" Height="16" VerticalAlignment="Center"
+                                               Classes="sidebar-chevron"
+                                               Classes.expanded="{Binding IsQuotaSubmenuExpanded}">
+                                            <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11"
+                                                                    HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         </Panel>
                                     </Grid>
                                 </Button>
@@ -256,11 +256,11 @@
                                                                HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         <TextBlock Grid.Column="1" Text="{l:Loc Sidebar_Fallback}" FontSize="13" VerticalAlignment="Center" Margin="6,0,0,0"
                                                    Opacity="{Binding SidebarContentOpacity}" />
-                                        <Panel Grid.Column="2" Width="16" VerticalAlignment="Center">
-                                            <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
-                                                                    IsVisible="{Binding IsFallbackSubmenuExpanded, Converter={StaticResource InvertBool}}" />
-                                            <lucide:PackIconLucide Kind="ChevronDown" Width="11" Height="11" Foreground="{DynamicResource FgMutedBrush}"
-                                                                    IsVisible="{Binding IsFallbackSubmenuExpanded}" />
+                                        <Panel Grid.Column="2" Width="16" Height="16" VerticalAlignment="Center"
+                                               Classes="sidebar-chevron"
+                                               Classes.expanded="{Binding IsFallbackSubmenuExpanded}">
+                                            <lucide:PackIconLucide Kind="ChevronRight" Width="11" Height="11"
+                                                                    HorizontalAlignment="Center" VerticalAlignment="Center" />
                                         </Panel>
                                     </Grid>
                                 </Button>


### PR DESCRIPTION
## Summary
- Make Quota and Fallback sidebar chevrons use the primary foreground color instead of muted gray
- Rotate a single chevron 90° with the same 0.18s CubicEaseOut transition as virtual-model expanders
- Apply the same white chevron color to virtual models in Fallback

## Test plan
- [ ] Open the expanded sidebar and confirm Quota/Fallback chevrons match the white icon/label color
- [ ] Toggle Quota and Fallback submenus and confirm the chevron rotates instead of swapping icons
- [ ] Open Fallback virtual models and confirm the expander chevron is white and still rotates on expand/collapse
- [ ] Check the same chevrons in light theme

Made with [Cursor](https://cursor.com)